### PR TITLE
Fix config stack loading with unit tests

### DIFF
--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -383,7 +383,7 @@ class Configuration(dict):
         for index, item in enumerate(configs):
             if isinstance(item, str):
                 configs[index] = LocalConf(item)
-            elif isinstance(item, dict):
+            elif not isinstance(item, LocalConf):
                 configs[index] = LocalConf(None)
                 configs[index].merge(item)
 
@@ -399,7 +399,8 @@ class Configuration(dict):
         # Merge all configs into one
         base = {}
         for cfg in configs:
-            is_user = cfg.path is None or cfg.path not in [Configuration.default, Configuration.system]
+            is_user = cfg.path is None or cfg.path not in [Configuration.default.path,
+                                                           Configuration.system.path]
             is_remote = cfg.path == Configuration.remote.path
             if (is_remote and skip_remote) or (is_user and skip_user):
                 continue

--- a/test/unittests/config_stack/default.yaml
+++ b/test/unittests/config_stack/default.yaml
@@ -1,0 +1,21 @@
+config_name: default
+system_only:
+  from_sys: False
+  from_rem: False
+  from_usr: False
+default_spec:
+  from_sys: False
+  from_rem: False
+  from_usr: False
+test:
+  default: True
+  system: False
+  user: False
+  remote: False
+default_only: default
+system:
+  protected_keys:
+    remote:
+      - default_spec
+    user:
+      - default_spec

--- a/test/unittests/config_stack/remote.yaml
+++ b/test/unittests/config_stack/remote.yaml
@@ -1,0 +1,11 @@
+config_name: remote
+system_only:
+  from_sys: False
+  from_rem: True
+  from_usr: False
+test:
+  user: False
+  remote: True
+default_spec:
+  from_rem: True
+remote_only: "remote"

--- a/test/unittests/config_stack/system.yaml
+++ b/test/unittests/config_stack/system.yaml
@@ -1,0 +1,21 @@
+config_name: system
+system_only:
+  from_sys: True
+  from_rem: False
+  from_usr: False
+default_spec:
+  from_sys: True
+test:
+  system: True
+  user: False
+  remote: False
+
+system:
+  protected_keys:
+    remote:
+      - system_only
+      - test:user
+    user:
+      - system_only
+      - test:remote
+      - user_only

--- a/test/unittests/config_stack/user.yaml
+++ b/test/unittests/config_stack/user.yaml
@@ -1,0 +1,11 @@
+config_name: user
+system_only:
+  from_sys: False
+  from_rem: False
+  from_usr: True
+test:
+  user: True
+  remote: False
+default_spec:
+  from_usr: True
+user_only: True

--- a/test/unittests/test_configuration.py
+++ b/test/unittests/test_configuration.py
@@ -90,7 +90,6 @@ class TestConfiguration(TestCase):
             self.assertEqual(json.loads(json.dumps(d)), d)
 
     def test_load_config_stack(self):
-        from ovos_config.config import Configuration
         test_dir = join(dirname(__file__), "config_stack")
         default_config = LocalConf(join(test_dir, "default.yaml"))
         system_config = LocalConf(join(test_dir, "system.yaml"))
@@ -100,7 +99,9 @@ class TestConfiguration(TestCase):
         Configuration.system = system_config
         Configuration.remote = remote_config
         Configuration.xdg_configs = [user_config]
-        Configuration.load_config_stack()
+        Configuration.__patch = LocalConf(None)
+        Configuration._old_user = LocalConf(None)
+        Configuration.load_all_configs()
         config = Configuration()
         # Test stack load order
         self.assertEqual(config["config_name"], "user")


### PR DESCRIPTION
Fix bug in `filter_and_merge` that caused all config objects to be identified as "user" configs
Add unit test to check config stack loading and system constraint handling