### PR TITLE
Fix version tags to include version bump commits

### DIFF
--- a/.github/workflows/publish_alpha.yml
+++ b/.github/workflows/publish_alpha.yml
@@ -1,4 +1,5 @@
 # This workflow will generate a distribution and upload it to PyPI
+# This will always use the current `dev` branch code
 
 name: Publish Alpha Build ...aX
 on:
@@ -64,6 +65,7 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: true
+          commitish: dev
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel

--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -1,4 +1,5 @@
 # This workflow will generate a distribution and upload it to PyPI
+# This will always use the current `dev` branch code
 
 name: Publish Build Release ..X
 on:
@@ -55,6 +56,7 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false
+          commitish: dev
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel

--- a/.github/workflows/publish_major.yml
+++ b/.github/workflows/publish_major.yml
@@ -1,4 +1,5 @@
 # This workflow will generate a distribution and upload it to PyPI
+# This will always use the current `dev` branch code and push it to `master`
 
 name: Publish Major Release X.0.0
 on:
@@ -55,6 +56,7 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false
+          commitish: master
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel

--- a/.github/workflows/publish_minor.yml
+++ b/.github/workflows/publish_minor.yml
@@ -1,4 +1,5 @@
 # This workflow will generate a distribution and upload it to PyPI
+# This will always use the current `dev` branch code and push it to `master`
 
 name: Publish Minor Release .X.0
 on:
@@ -55,6 +56,7 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false
+          commitish: master
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel


### PR DESCRIPTION
Update publish actions to specify commit in Release actions to include any changes performed by the Action
Addresses a bug reported by @puretryout
Validated alpha workflow on fork: https://github.com/NeonDaniel/ovos-config/releases/tag/V0.0.4a4 Note that the commit associated with that tag is the latest on `dev` branch to match the code that would be built/pushed to PyPI