### PR TITLE
Load as well the OVOS specific configs.

### DIFF
--- a/test/unittests/test_configuration.py
+++ b/test/unittests/test_configuration.py
@@ -125,7 +125,7 @@ class TestConfiguration(TestCase):
         Configuration.default = default_config
         Configuration.system = system_config
         Configuration.remote = remote_config
-        Configuration.xdg_configs = [user_config]
+        Configuration.ovos_configs = [user_config]
         Configuration.__patch = LocalConf(None)
         Configuration._old_user = LocalConf(None)
         Configuration.load_all_configs()


### PR DESCRIPTION
This PR changes get_xdg_config_locations() to get_ovos_default_config_paths().

With this changes, the path /etc/OpenVoiceOS/ovos.conf is also loaded.
Without this PR, the logs configuration is not loaded correctly and it's impossible to have the logs sent to a specific directory without using as well another config file.