### PR TITLE
Handle empty config load

### DIFF
--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -111,21 +111,6 @@ def find_default_config():
         # mycroft-core not found
         return join(dirname(__file__), "mycroft.conf")
 
-import inspect
-stack = inspect.stack()
-
-# Record:
-# [0] - frame object
-# [1] - filename
-# [2] - line number
-# [3] - function
-# ...
-for record in stack:
-    try:
-        LOG.info(f"{record[1]}:{record[2]}")
-    except:
-        LOG.error(record)
-LOG.info("Initializing Configuration Paths")
 DEFAULT_CONFIG = _ovos_config.get_ovos_config()['default_config_path']
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
                                f'/etc/{_ovos_config.get_xdg_base()}/'

--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -16,7 +16,7 @@ from os.path import join, dirname, expanduser, exists, isfile
 from time import sleep
 import ovos_config.meta as _ovos_config
 from ovos_utils.xdg_utils import xdg_config_dirs, xdg_config_home, xdg_data_dirs, xdg_data_home, xdg_cache_home
-
+from ovos_utils.log import LOG
 
 def get_xdg_config_dirs(folder=None):
     """ return list of possible XDG config dirs taking into account ovos.conf """
@@ -111,7 +111,21 @@ def find_default_config():
         # mycroft-core not found
         return join(dirname(__file__), "mycroft.conf")
 
+import inspect
+stack = inspect.stack()
 
+# Record:
+# [0] - frame object
+# [1] - filename
+# [2] - line number
+# [3] - function
+# ...
+for record in stack:
+    try:
+        LOG.info(f"{record[1]}:{record[2]}")
+    except:
+        LOG.error(record)
+LOG.info("Initializing Configuration Paths")
 DEFAULT_CONFIG = _ovos_config.get_ovos_config()['default_config_path']
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
                                f'/etc/{_ovos_config.get_xdg_base()}/'

--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -16,7 +16,7 @@ from os.path import join, dirname, expanduser, exists, isfile
 from time import sleep
 import ovos_config.meta as _ovos_config
 from ovos_utils.xdg_utils import xdg_config_dirs, xdg_config_home, xdg_data_dirs, xdg_data_home, xdg_cache_home
-from ovos_utils.log import LOG
+
 
 def get_xdg_config_dirs(folder=None):
     """ return list of possible XDG config dirs taking into account ovos.conf """
@@ -110,6 +110,7 @@ def find_default_config():
     except FileNotFoundError:
         # mycroft-core not found
         return join(dirname(__file__), "mycroft.conf")
+
 
 DEFAULT_CONFIG = _ovos_config.get_ovos_config()['default_config_path']
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -90,9 +90,12 @@ class LocalConf(dict):
                             config = yaml.safe_load(f)
                     else:
                         config = load_commented_json(path)
-                    for key in config:
-                        self.__setitem__(key, config[key])
-                    LOG.debug(f"Configuration {path} loaded")
+                    if config:
+                        for key in config:
+                            self.__setitem__(key, config[key])
+                        LOG.debug(f"Configuration {path} loaded")
+                    else:
+                        LOG.warning(f"Empty config found at: {path}")
                 except Exception as e:
                     LOG.exception(f"Error loading configuration '{path}'")
         else:

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -95,7 +95,7 @@ class LocalConf(dict):
                             self.__setitem__(key, config[key])
                         LOG.debug(f"Configuration {path} loaded")
                     else:
-                        LOG.warning(f"Empty config found at: {path}")
+                        LOG.debug(f"Empty config found at: {path}")
                 except Exception as e:
                     LOG.exception(f"Error loading configuration '{path}'")
         else:


### PR DESCRIPTION
Catch and log an empty config file instead of handling in catch-all exception handling