### PR TITLE
fix system_unit comment

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -22,7 +22,7 @@
   // TODO: save unmodified, lowercase upon demand
   "lang": "en-us",
 
-  // Measurement units, either 'metric' or 'english'
+  // Measurement units, either 'metric' or 'imperial'
   // Override: REMOTE
   "system_unit": "metric",
 


### PR DESCRIPTION
ovos (owm in particular) is working with `imperial` instead of `english`. 