### PR TITLE
Bump PyYAML to 6.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML~=6.0
+PyYAML>=5.4.0,<7.0.0
 watchdog
 combo_lock
 python-dateutil~=2.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML~=5.4
+PyYAML==6.0
 watchdog
 combo_lock
 python-dateutil~=2.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==6.0
+PyYAML~=6.0
 watchdog
 combo_lock
 python-dateutil~=2.6


### PR DESCRIPTION
Installing the alpha version via `pip install --pre` returns this error because of PyYAML 5.4.1, using PyYAML 6.0 doesn't return any error.
```
#0 1.827 Collecting PyYAML~=5.4
#0 1.841   Downloading PyYAML-5.4.1.tar.gz (175 kB)
#0 1.847      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 30.8 MB/s eta 0:00:00
#0 1.925   Installing build dependencies: started
#0 3.647   Installing build dependencies: finished with status 'done'
#0 3.649   Getting requirements to build wheel: started
#0 3.767   Getting requirements to build wheel: finished with status 'error'
#0 3.773   error: subprocess-exited-with-error
#0 3.773   
#0 3.773   × Getting requirements to build wheel did not run successfully.
#0 3.773   │ exit code: 1
#0 3.773   ╰─> [68 lines of output]
#0 3.773       /tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
#0 3.773       !!
#0 3.773       
#0 3.773               ********************************************************************************
#0 3.773               The license_file parameter is deprecated, use license_files instead.
#0 3.773       
#0 3.773               By 2023-Oct-30, you need to update your project and remove deprecated calls
#0 3.773               or your builds will no longer be supported.
#0 3.773       
#0 3.773               See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
#0 3.773               ********************************************************************************
#0 3.773       
#0 3.773       !!
#0 3.773         parsed = self.parsers.get(option_name, lambda x: x)(value)
#0 3.773       running egg_info
#0 3.773       writing lib3/PyYAML.egg-info/PKG-INFO
#0 3.773       writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
#0 3.773       writing top-level names to lib3/PyYAML.egg-info/top_level.txt
#0 3.773       Traceback (most recent call last):
#0 3.773         File "/home/ovos/.venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#0 3.773           main()
#0 3.773         File "/home/ovos/.venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#0 3.773           json_out['return_val'] = hook(**hook_input['kwargs'])
#0 3.773                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 3.773         File "/home/ovos/.venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
#0 3.773           return hook(config_settings)
#0 3.773                  ^^^^^^^^^^^^^^^^^^^^^
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
#0 3.773           return self._get_build_requires(config_settings, requirements=['wheel'])
#0 3.773                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
#0 3.773           self.run_setup()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
#0 3.773           exec(code, locals())
#0 3.773         File "<string>", line 271, in <module>
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
#0 3.773           return distutils.core.setup(**attrs)
#0 3.773                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
#0 3.773           return run_commands(dist)
#0 3.773                  ^^^^^^^^^^^^^^^^^^
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
#0 3.773           dist.run_commands()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
#0 3.773           self.run_command(cmd)
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 1244, in run_command
#0 3.773           super().run_command(command)
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#0 3.773           cmd_obj.run()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 317, in run
#0 3.773           self.find_sources()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 325, in find_sources
#0 3.773           mm.run()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 573, in run
#0 3.773           self.add_defaults()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 611, in add_defaults
#0 3.773           sdist.add_defaults(self)
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 106, in add_defaults
#0 3.773           super().add_defaults()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
#0 3.773           self._add_defaults_ext()
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
#0 3.773           self.filelist.extend(build_ext.get_source_files())
#0 3.773                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 3.773         File "<string>", line 201, in get_source_files
#0 3.773         File "/tmp/pip-build-env-al4na6p3/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
#0 3.773           raise AttributeError(attr)
#0 3.773       AttributeError: cython_sources
#0 3.773       [end of output]
#0 3.773   
#0 3.773   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 3.774 error: subprocess-exited-with-error
#0 3.774 
#0 3.774 × Getting requirements to build wheel did not run successfully.
#0 3.774 │ exit code: 1
#0 3.774 ╰─> See above for output.
#0 3.774 
#0 3.774 note: This error originates from a subprocess, and is likely not a problem with pip.
```