### PR TITLE
Support envvar default configuration overrides

### DIFF
--- a/ovos_config/meta.py
+++ b/ovos_config/meta.py
@@ -45,6 +45,7 @@ Examples config:
    }
 }
 """
+import os
 from os.path import isfile, join, dirname
 
 from json_database import JsonStorage
@@ -55,19 +56,23 @@ from ovos_utils.log import LOG
 
 
 def get_ovos_config():
-    """ load ovos.conf
-    goes trough all possible ovos.conf paths and loads them in order
-
-    submodule overrides are applied to the final config if overrides are defined for the caller module
-        eg, if neon-core is calling this method then neon config overrides are loaded
+    """
+    Goes through all possible ovos.conf paths and loads them in order. Default
+    `base_folder` and `config_filename` are overridden by envvars
+    `OVOS_CONFIG_BASE_FOLDER` and `OVOS_CONFIG_FILENAME`, respectively.
+    Submodule overrides are applied to the final config if defined for the
+    calling module.
+    eg, if neon is calling this method then neon config overrides are loaded
 
     """
     from ovos_utils.system import is_running_from_module
 
     # populate default values
     config = {"xdg": True,
-              "base_folder": "mycroft",
-              "config_filename": "mycroft.conf"}
+              "base_folder": os.environ.get("OVOS_CONFIG_BASE_FOLDER") or
+              "mycroft",
+              "config_filename": os.environ.get("OVOS_CONFIG_FILENAME") or
+              "mycroft.conf"}
     try:
         config["default_config_path"] = _oloc.find_default_config()
     except FileNotFoundError:  # not a mycroft device

--- a/test/unittests/test_meta.py
+++ b/test/unittests/test_meta.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+
+from os.path import join, dirname
+
+
+class TestMeta(unittest.TestCase):
+    test_dir = join(dirname(__file__), "test_meta")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        os.environ["XDG_CONFIG_HOME"] = cls.test_dir
+        os.makedirs(cls.test_dir, exist_ok=True)
+
+    def test_get_ovos_config(self):
+        from ovos_config.meta import get_ovos_config
+        default = get_ovos_config()
+        self.assertEqual(default['base_folder'], "mycroft")
+        self.assertEqual(default['config_filename'], "mycroft.conf")
+
+        os.environ['OVOS_CONFIG_BASE_FOLDER'] = 'test'
+        default = get_ovos_config()
+        self.assertEqual(default['base_folder'], "test")
+        self.assertEqual(default['config_filename'], "mycroft.conf")
+
+        os.environ['OVOS_CONFIG_FILENAME'] = 'test.yaml'
+        default = get_ovos_config()
+        self.assertEqual(default['base_folder'], "test")
+        self.assertEqual(default['config_filename'], "test.yaml")
+
+        # TODO: Test module_overrides
+
+    def test_save_ovos_config(self):
+        from ovos_config.meta import save_ovos_config
+        # TODO
+
+    def test_get_ovos_default_config_paths(self):
+        from ovos_config.meta import get_ovos_default_config_paths
+        # TODO
+
+    def test_get_xdg_base(self):
+        from ovos_config.meta import get_xdg_base
+        # TODO
+
+    def test_set_xdg_base(self):
+        from ovos_config.meta import set_xdg_base
+        # TODO
+
+    def test_set_config_filename(self):
+        from ovos_config.meta import set_config_filename
+        # TODO
+
+    def test_get_config_filename(self):
+        from ovos_config.meta import get_config_filename
+        # TODO
+
+    def test_set_default_config(self):
+        from ovos_config.meta import set_default_config
+        # TODO


### PR DESCRIPTION
Add envvar handling for default config base folder and filename with unit tests
Outline meta module unit tests
Closes #46 