### PR TITLE
Fix infinitely recursive callback

### DIFF
--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -295,9 +295,6 @@ class Configuration(dict):
         for cfg in Configuration.xdg_configs + [Configuration.system,
                                                 Configuration.remote]:
             if cfg.path == path:
-                if cfg.reloading:
-                    LOG.error("Asked to reload file while already reloading!")
-                    continue
                 old_cfg = hash(cfg)
                 try:
                     cfg.reload()

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -204,7 +204,7 @@ class RemoteConf(LocalConf):
             remote = RemoteConfigManager()
 
             remote.download()
-            if hash(remote) == hash(self):
+            if remote.config == dict(self):
                 LOG.info("No changes from remote")
                 return
             for key in remote.config:

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -121,8 +121,8 @@ class LocalConf(dict):
 
     def reload(self):
         if self._last_loaded == getmtime(self.path):
-            LOG.debug(f"File not changed since last load "
-                      f"({time() - self._last_loaded} seconds ago)")
+            LOG.debug(f"{self.path} not changed since last load "
+                      f"(changed {time() - self._last_loaded} seconds ago)")
             return
         self.load_local(self.path)
 

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -209,7 +209,7 @@ class RemoteConf(LocalConf):
                 return
             for key in remote.config:
                 self.__setitem__(key, remote.config[key])
-
+            LOG.debug(f"writing remote config to {self.path}")
             self.store(self.path)
 
         except Exception as e:

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -204,6 +204,9 @@ class RemoteConf(LocalConf):
             remote = RemoteConfigManager()
 
             remote.download()
+            if hash(remote) == hash(self):
+                LOG.info("No changes from remote")
+                return
             for key in remote.config:
                 self.__setitem__(key, remote.config[key])
 

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 #
 import json
+import yaml
+
+from time import time
 from os.path import exists, isfile, getmtime
 from combo_lock import NamedLock
-import yaml
 from ovos_utils.json_helper import load_commented_json, merge_dict
 from ovos_utils.log import LOG
 
@@ -119,7 +121,8 @@ class LocalConf(dict):
 
     def reload(self):
         if self._last_loaded == getmtime(self.path):
-            LOG.info(f"File not changed since last load")
+            LOG.debug(f"File not changed since last load "
+                      f"({time() - self._last_loaded} seconds ago)")
             return
         self.load_local(self.path)
 

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -61,7 +61,6 @@ class LocalConf(dict):
     def __init__(self, path):
         super().__init__(self)
         self.path = path
-        self.reloading = False
         self._last_loaded = None
         if path:
             self.load_local(path)
@@ -120,7 +119,7 @@ class LocalConf(dict):
 
     def reload(self):
         if self._last_loaded == getmtime(self.path):
-            LOG.debug(f"File not changed since last load")
+            LOG.info(f"File not changed since last load")
             return
         self.load_local(self.path)
 
@@ -204,9 +203,6 @@ class RemoteConf(LocalConf):
             remote = RemoteConfigManager()
 
             remote.download()
-            if remote.config == dict(self):
-                LOG.info("No changes from remote")
-                return
             for key in remote.config:
                 self.__setitem__(key, remote.config[key])
             LOG.debug(f"writing remote config to {self.path}")

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -54,13 +54,14 @@ class LocalConf(dict):
     allow_overwrite = True
     # lock is shared among all subclasses,
     # regardless of what file is being edited only one file should change at a time
-    # this ensure orderly behaviour in anything monitoring changes,
+    # this ensures orderly behaviour in anything monitoring changes,
     #   eg FileWatcher util, configuration.patch bus handlers
     __lock = NamedLock("ovos_config")
 
     def __init__(self, path):
         super().__init__(self)
         self.path = path
+        self.reloading = False
         if path:
             self.load_local(path)
 
@@ -85,7 +86,8 @@ class LocalConf(dict):
             return "json"
 
     def load_local(self, path=None):
-        """Load local json file into self.
+        """
+        Load local json file into self.
 
         Args:
             path (str): file to load
@@ -114,7 +116,9 @@ class LocalConf(dict):
             LOG.debug(f"Configuration '{path}' not defined, skipping")
 
     def reload(self):
+        self.reloading = True
         self.load_local(self.path)
+        self.reloading = False
 
     def store(self, path=None):
         path = path or self.path


### PR DESCRIPTION
Cleans up exception handling to remove some reload patching that no longer applies since files are reloaded only on close
Adds a check for file modification time before reloading to resolve the observed condition where several services try to reload a configuration file, causing an infinite recursion of file closes triggering config reload

```
2023-07-19 17:01:51.496 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
2023-07-19 17:01:51.518 - gui - ovos_config.config:_on_file_change:311 - INFO - /home/neon/.config/neon/web_cache.json unchanged
2023-07-19 17:01:51.544 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
2023-07-19 17:01:51.580 - gui - ovos_config.config:_on_file_change:311 - INFO - /home/neon/.config/neon/web_cache.json unchanged
2023-07-19 17:01:51.605 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
2023-07-19 17:01:51.623 - gui - ovos_config.config:_on_file_change:311 - INFO - /home/neon/.config/neon/web_cache.json unchanged
2023-07-19 17:01:51.648 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
2023-07-19 17:01:51.683 - gui - ovos_config.config:_on_file_change:311 - INFO - /home/neon/.config/neon/web_cache.json unchanged
2023-07-19 17:01:51.717 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
2023-07-19 17:01:51.760 - gui - ovos_config.config:_on_file_change:311 - INFO - /home/neon/.config/neon/web_cache.json unchanged
2023-07-19 17:01:51.850 - gui - ovos_backend_client.backends.offline:device_get_settings:208 - WARNING - Offline Backend, you may want to reference `ovos_config.Configuration()` to get full config
```