### PR TITLE
fix subclassing for deprecation

### DIFF
--- a/ovos_config/utils.py
+++ b/ovos_config/utils.py
@@ -8,13 +8,30 @@ from os.path import join, dirname
 from ovos_utils.xdg_utils import xdg_config_home
 
 try:
-    # TODO: Consider deprecating these before 0.1.0
+    # TODO: deprecate in 0.0.12, leave only during 0.0.11 life cycle
     from ovos_utils.file_utils import FileWatcher as _FileWatcher, \
         FileEventHandler as _FileEventHandler
+
+
+    class FileWatcher(_FileWatcher):
+        def __init__(self, *args, **kwargs):
+            if _FileWatcher is None:
+                raise ImportError("Import from ovos_utils.file_utils directly")
+            _FileWatcher.__init__(self, *args, **kwargs)
+            log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")
+
+
+    class FileEventHandler(_FileEventHandler):
+        def __init__(self, *args, **kwargs):
+            if _FileEventHandler is None:
+                raise ImportError("Import from ovos_utils.file_utils directly")
+            _FileEventHandler.__init__(self, *args, **kwargs)
+            log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")
+
 except ImportError:
     LOG.debug("Failed to import `FileWatcher` and `FileEventHandler`")
-    _FileWatcher = None
-    _FileEventHandler = None
+    FileWatcher = None
+    FileEventHandler = None
 
 
 def init_module_config(module_name: str, module_override: str,
@@ -91,18 +108,3 @@ def init_module_config(module_name: str, module_override: str,
     importlib.reload(ovos_config.config)
     importlib.reload(ovos_config)
 
-
-class FileWatcher(_FileWatcher):
-    def __init__(self, *args, **kwargs):
-        if _FileWatcher is None:
-            raise ImportError("Import from ovos_utils.file_utils directly")
-        _FileWatcher.__init__(self, *args, **kwargs)
-        log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")
-
-
-class FileEventHandler(_FileEventHandler):
-    def __init__(self, *args, **kwargs):
-        if _FileEventHandler is None:
-            raise ImportError("Import from ovos_utils.file_utils directly")
-        _FileEventHandler.__init__(self, *args, **kwargs)
-        log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")


### PR DESCRIPTION
fixes #64, dont subclass None....

```
/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/ovos_config/utils.py:95: in <module>
    class FileWatcher(_FileWatcher):
E   TypeError: NoneType takes no arguments
```