### PR TITLE
fix remote config reload

### DIFF
--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -20,7 +20,7 @@ from ovos_config.models import LocalConf, MycroftDefaultConfig, \
     MycroftSystemConfig, MycroftUserConfig, RemoteConf
 from ovos_config.locations import OLD_USER_CONFIG, get_xdg_config_save_path, \
     get_xdg_config_locations
-from ovos_config.utils import FileWatcher
+from ovos_utils.file_utils import FileWatcher
 
 from ovos_utils.json_helper import flattened_delete, merge_dict
 from ovos_utils.log import LOG

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -189,7 +189,7 @@ class MycroftSystemConfig(ReadOnlyConfig):
 
 
 class RemoteConf(LocalConf):
-    """Config dictionary fetched from mycroft.ai."""
+    """Config dictionary fetched from the backend"""
 
     def __init__(self, cache=WEB_CONFIG_CACHE):
         super(RemoteConf, self).__init__(cache)
@@ -204,12 +204,17 @@ class RemoteConf(LocalConf):
                 return
 
             remote = RemoteConfigManager()
-
             remote.download()
+
+            changed = []
             for key in remote.config:
-                self.__setitem__(key, remote.config[key])
-            LOG.debug(f"writing remote config to {self.path}")
-            self.store(self.path)
+                if self.get(key) != remote.config[key]:
+                    changed.append(key)
+                    self.__setitem__(key, remote.config[key])
+
+            if changed:
+                LOG.debug(f"config key(s) {changed} changed, writing remote config to {self.path}")
+                self.store(self.path)
 
         except Exception as e:
             LOG.error(f"Exception fetching remote configuration: {e}")


### PR DESCRIPTION
- set and store remote config (keys) only when changed
- more verbose debug logging to see what has changed
- import FileWatcher from `ovos_utils.file_utils` (`ovos_config.utils` deprecated)