### PR TITLE
Minor dependency and logging updates

### DIFF
--- a/ovos_config/utils.py
+++ b/ovos_config/utils.py
@@ -18,7 +18,8 @@ try:
             if _FileWatcher is None:
                 raise ImportError("Import from ovos_utils.file_utils directly")
             _FileWatcher.__init__(self, *args, **kwargs)
-            log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")
+            log_deprecation("Import from ovos_utils.file_utils directly",
+                            "0.0.12")
 
 
     class FileEventHandler(_FileEventHandler):
@@ -26,7 +27,8 @@ try:
             if _FileEventHandler is None:
                 raise ImportError("Import from ovos_utils.file_utils directly")
             _FileEventHandler.__init__(self, *args, **kwargs)
-            log_deprecation("Import from ovos_utils.file_utils directly", "0.1.0")
+            log_deprecation("Import from ovos_utils.file_utils directly",
+                            "0.0.12")
 
 except ImportError:
     LOG.debug("Failed to import `FileWatcher` and `FileEventHandler`")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML>=5.4.0,<7.0.0
-watchdog
-combo_lock
+combo_lock~=0.2
 python-dateutil~=2.6
 ovos-utils < 0.1.0
-rich-click
+rich-click ~=1.6


### PR DESCRIPTION
Update deprecation notices to match commented deprecation version
Remove `watchdog` dependency for code moved to ovos-utils