### PR TITLE
add audio service ducking default config

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -696,7 +696,8 @@
         "active": true
       }
     },
-    // audio service ducking - lowering volume of background audio when TTS is playing
+    // audio service ducking - lowering volume of background audio when TTS or system sound 
+    // is playing
     // NOTE: If the TTS config 'pulse_duck' is set to true, this setting will be ignored
     // and pulse audio role ducking will be used instead.
     "duck": true,


### PR DESCRIPTION
Lately, audio service ducking was introduced to https://github.com/OpenVoiceOS/ovos-audio/commit/0a3b0345664025a9ba6348c053edc1e05f005239 

This makes the audio service ducking the default configuration
_("Audio service ducking" will be invalidated if `"pulse_duck": true` is configured, ie. pulse is taking over to perform said task.)_