### PR TITLE
fix: no homescreen by default

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -130,7 +130,7 @@
 
      // cancel utterances mid command
      "ovos-utterance-plugin-cancel": {},
-      
+
      // define utterance fixes via fuzzy match ~/.local/share/mycroft/corrections.json
      // define unconditional replacements at word level ~/.local/share/mycroft/word_corrections.json
      "ovos-utterance-corrections-plugin": {}
@@ -495,7 +495,7 @@
     "recording_timeout": 10.0,
     "recording_timeout_with_silence": 3.0,
 
-    // Skips all checks (eg. audio service confirmation) after the wake_word is recognized and 
+    // Skips all checks (eg. audio service confirmation) after the wake_word is recognized and
     // instantly continues to listen for a command
     "instant_listen": false,
 
@@ -575,7 +575,7 @@
   "gui": {
     // Override: SYSTEM (set by specific enclosures)
     // Uncomment or add "idle_display_skill" to set initial homescreen
-    "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
+    // "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
 
     // Extensions provide additional GUI platform support for specific devices
     // Currently supported devices: smartspeaker, bigscreen or generic
@@ -584,7 +584,7 @@
     // Generic extension can additionaly provide homescreen functionality
     // homescreen support is disabled by default for generic extension
     "generic": {
-        "homescreen_supported": true
+        "homescreen_supported": false
     }
   },
 


### PR DESCRIPTION
Somewhere along the lines, the `idle_display_skill` and 'generic' type had '"homescreen_supported": true" where the comment above specifically states that the `generic` type does NOT have the homescreen support by default.