### PR TITLE
feat: add /usr/share as a config location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 
 # Created by unit tests
 .pytest_cache/
+test_conf.json

--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -17,7 +17,8 @@ from os.path import isfile
 from typing import Optional
 
 from ovos_config.models import LocalConf, MycroftDefaultConfig, \
-    MycroftSystemConfig, MycroftUserConfig, RemoteConf
+    OvosDistributionConfig, MycroftSystemConfig, MycroftUserConfig, \
+    RemoteConf
 from ovos_config.locations import OLD_USER_CONFIG, get_xdg_config_save_path, \
     get_xdg_config_locations
 from ovos_utils.file_utils import FileWatcher
@@ -41,6 +42,7 @@ class Configuration(dict):
     __patch = LocalConf(None)  # Patch config that skills can update to override config
     bus = None
     default = MycroftDefaultConfig()
+    distribution = OvosDistributionConfig()
     system = MycroftSystemConfig()
     remote = RemoteConf()
     # This includes both the user config and
@@ -156,13 +158,14 @@ class Configuration(dict):
     @staticmethod
     def get_system_constraints() -> dict:
         """
-        Get Configuration constraints. Constraints must come from SYSTEM config.
+        Get Configuration constraints. Constraints must come from DISTRIBUTION or SYSTEM config.
         If not defined, then load the DEFAULT constraints.
         These settings can not be set anywhere else!
         @return: dict of system configuration constraints
         """
 
-        return Configuration.system.get("system") or \
+        return Configuration.distribution.get("system") or \
+            Configuration.system.get("system") or \
             Configuration.default.get("system") or \
             {}
 
@@ -180,7 +183,7 @@ class Configuration(dict):
         skip_user = system_constraints.get("disable_user_config", False)
         skip_remote = system_constraints.get("disable_remote_config", False)
 
-        configs = [Configuration.default, Configuration.system]
+        configs = [Configuration.default, Configuration.distribution, Configuration.system]
         if not skip_remote:
             configs.insert(1, Configuration.remote)
         if not skip_user:
@@ -271,7 +274,7 @@ class Configuration(dict):
         Setup filewatcher to monitor for config file changes
         @param callback: optional method to call when configuration is changed
         """
-        paths = [Configuration.system.path] + \
+        paths = [Configuration.distribution.path, Configuration.system.path] + \
                 [c.path for c in Configuration.xdg_configs]
         if callback and callback not in Configuration._callbacks:
             Configuration._callbacks.append(callback)
@@ -288,7 +291,8 @@ class Configuration(dict):
         @param path: Configuration file path reporting a change
         """
         # reload updated config
-        for cfg in Configuration.xdg_configs + [Configuration.system,
+        for cfg in Configuration.xdg_configs + [Configuration.distribution,
+                                                Configuration.system,
                                                 Configuration.remote]:
             if cfg.path == path:
                 old_cfg = hash(cfg)

--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -55,8 +55,8 @@ def find_user_config():
     if isfile(path):
         return path
     old, path = get_config_locations(default=False, web_cache=False,
-                                     system=False, old_user=True,
-                                     user=True)
+                                     distribution=False, system=False,
+                                     old_user=True, user=True)
     if isfile(path):
         return path
     if isfile(old):
@@ -64,13 +64,15 @@ def find_user_config():
     return path
 
 
-def get_config_locations(default=True, web_cache=True, system=True,
-                         old_user=True, user=True):
+def get_config_locations(default=True, web_cache=True, distribution=True,
+                         system=True, old_user=True, user=True):
     """return list of all possible config files paths sorted by priority taking into account ovos.conf"""
     locs = []
     ovos_cfg = _ovos_config.get_ovos_config()
     if default:
         locs.append(ovos_cfg["default_config_path"])
+    if distribution:
+        locs.append(f"/usr/share/{ovos_cfg['base_folder']}/{ovos_cfg['config_filename']}")
     if system:
         locs.append(f"/etc/{ovos_cfg['base_folder']}/{ovos_cfg['config_filename']}")
     if web_cache:
@@ -104,6 +106,9 @@ def find_default_config():
 
 
 DEFAULT_CONFIG = _ovos_config.get_ovos_config()['default_config_path']
+DISTRIBUTION_CONFIG = os.environ.get('OVOS_DISTRIBUTION_CONFIG',
+                               f'/usr/share/{_ovos_config.get_xdg_base()}/'
+                               f'{_ovos_config.get_config_filename()}')
 SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
                                f'/etc/{_ovos_config.get_xdg_base()}/'
                                f'{_ovos_config.get_config_filename()}')

--- a/ovos_config/meta.py
+++ b/ovos_config/meta.py
@@ -3,6 +3,7 @@
 The ovos config is json with comment support like the regular mycroft.conf
 
 Default locations tried by order until a file is found
+- /usr/share/OpenVoiceOS/ovos.conf
 - /etc/OpenVoiceOS/ovos.conf
 - /etc/mycroft/ovos.conf
 
@@ -116,12 +117,14 @@ def save_ovos_config(new_config):
 def get_ovos_default_config_paths():
     """ return a list of all existing ovos.conf file locations by order of precedence
 
-     eg. ["/etc/OpenVoiceOS/ovos.conf", "/home/user/.config/OpenVoiceOS/ovos.conf"]
+     eg. ["/usr/share/OpenVoiceOS/ovos.conf", "/etc/OpenVoiceOS/ovos.conf", "/home/user/.config/OpenVoiceOS/ovos.conf"]
 
      """
     from ovos_utils.log import LOG
 
     paths = []
+    if isfile("/usr/share/OpenVoiceOS/ovos.conf"):
+        paths.append("/usr/share/OpenVoiceOS/ovos.conf")
     if isfile("/etc/OpenVoiceOS/ovos.conf"):
         paths.append("/etc/OpenVoiceOS/ovos.conf")
     elif isfile("/etc/mycroft/ovos.conf"):

--- a/ovos_config/models.py
+++ b/ovos_config/models.py
@@ -21,7 +21,7 @@ from combo_lock import NamedLock
 from ovos_utils.json_helper import load_commented_json, merge_dict
 from ovos_utils.log import LOG
 
-from ovos_config.locations import USER_CONFIG, SYSTEM_CONFIG, WEB_CONFIG_CACHE, DEFAULT_CONFIG
+from ovos_config.locations import USER_CONFIG, DISTRIBUTION_CONFIG, SYSTEM_CONFIG, WEB_CONFIG_CACHE, DEFAULT_CONFIG
 
 
 def is_remote_list(values):
@@ -183,6 +183,11 @@ class MycroftDefaultConfig(ReadOnlyConfig):
         # in case we got it wrong / non standard
         self.path = root_config
         self.reload()
+
+
+class OvosDistributionConfig(ReadOnlyConfig):
+    def __init__(self, allow_overwrite=False):
+        super().__init__(DISTRIBUTION_CONFIG, allow_overwrite)
 
 
 class MycroftSystemConfig(ReadOnlyConfig):

--- a/test/unittests/test_locations.py
+++ b/test/unittests/test_locations.py
@@ -55,10 +55,12 @@ class TestLocations(TestCase):
         webcache_loc.return_value = "webcache"
         from ovos_config.locations import get_config_locations
         self.assertEqual(get_config_locations(False, False, False,
-                                              False, False), list())
+                                              False, False, False
+                                              ), list())
         self.assertEqual(get_config_locations(),
-                         ['/test/default.yml', '/etc/test/test.yaml',
-                          'webcache', '~/.test/test.yaml', 'config/test.yaml'])
+                         ['/test/default.yml', '/usr/share/test/test.yaml',
+                          '/etc/test/test.yaml', 'webcache',
+                          '~/.test/test.yaml', 'config/test.yaml'])
 
 
     @mock.patch("ovos_config.meta.get_config_filename")
@@ -70,6 +72,7 @@ class TestLocations(TestCase):
         xdg_base.return_value = "test"
         config_filename.return_value = "test.yaml"
         mod_check.return_value = False
+        os.environ["OVOS_DISTRIBUTION_CONFIG"] = "mycroft/distribution/config"
         os.environ["MYCROFT_SYSTEM_CONFIG"] = "mycroft/system/config"
         os.environ["MYCROFT_WEB_CACHE"] = "mycroft/web/config"
 
@@ -86,9 +89,11 @@ class TestLocations(TestCase):
         importlib.reload(ovos_config.meta)
 
         # Test all config paths respect environment overrides/configured values
-        from ovos_config.locations import DEFAULT_CONFIG, SYSTEM_CONFIG, \
-            OLD_USER_CONFIG, USER_CONFIG, REMOTE_CONFIG, WEB_CONFIG_CACHE
+        from ovos_config.locations import DEFAULT_CONFIG, DISTRIBUTION_CONFIG, \
+            SYSTEM_CONFIG, OLD_USER_CONFIG, USER_CONFIG, REMOTE_CONFIG, \
+            WEB_CONFIG_CACHE
 
+        self.assertEqual(DISTRIBUTION_CONFIG, "mycroft/distribution/config")
         self.assertEqual(SYSTEM_CONFIG, "mycroft/system/config")
         self.assertEqual(OLD_USER_CONFIG,
                          expanduser("~/.test/test.yaml"))


### PR DESCRIPTION
/usr/share/<application name> is becoming more and more common for applications to store their default configuration in. Either the application itself or distributions can use this location to ship a config that users will not touch, and instead they are expected to overwrite (parts of) the config in /etc/<application name>. This means this config file can be safely updated with new required values without having to worry about overwriting user-made change.

This is useful in general but especially in case of immutable distributions who don't touch anything in /etc and /home