### PR TITLE
better listener defaults

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -448,6 +448,9 @@
       "module": "ovos-microphone-plugin-alsa"
     },
 
+    // if true, will remove silence from both ends of audio before sending it to STT
+    "remove_silence": true,
+
     // Voice Activity Detection is used to determine when speech ended
     "VAD": {
         // silence method defined the main vad strategy
@@ -513,7 +516,7 @@
 
     // Skips all checks (eg. audio service confirmation) after the wake_word is recognized and 
     // instantly continues to listen for a command
-    "instant_listen": false,
+    "instant_listen": true,
 
     // continuous listen is an experimental setting, it removes the need for
     // wake words and uses VAD only, a streaming STT is strongly recommended


### PR DESCRIPTION
use instant_listen by default, avoids https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/107 until fixed

enabled remove_silence by default, further making the above a better default  (as listen sound gets removed by silero vad), safe to do since https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/122