### PR TITLE
tweak OCP defaults

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -168,12 +168,17 @@
     },
 
     "OCP": {
+      // enable usage of a pretrained classifier for MediaType matching
+      // if disabled a simple .voc match is used
+      // NOTE: classifiers currently are english only
+      "experimental_media_classifier": false,
+      "experimental_binary_classifier": false,
       // legacy forces old audio service instead of OCP
       "legacy": false,
       // min confidence (0.0 - 1.0) to accept MediaType
       "classifier_threshold": 0.4,
       // min conf for each result (0 - 100)
-      "min_score": 50,
+      "min_score": 40,
       // filter results from "wrong" MediaType
       "filter_media": true,
       // filter results we lack plugins to play


### PR DESCRIPTION
default to keyword matching instead of using the new classifier (companion to https://github.com/OpenVoiceOS/ovos-core/pull/502)

reduce min_score from 50 to 40 so more results are considered