### PR TITLE
feat:fallback_plugins

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -487,10 +487,10 @@
     },
 
     // Microphone plugin to be read audio
-    // NOTE: only in ovos-dinkum-listener
     "microphone": {
-      // use "ovos-microphone-plugin-sounddevice" for MacOS support
-      "module": "ovos-microphone-plugin-alsa"
+      "module": "ovos-microphone-plugin-sounddevice",
+      "ovos-microphone-plugin-sounddevice": {"fallback_module": "ovos-microphone-plugin-alsa"},
+      "ovos-microphone-plugin-alsa": {"fallback_module": "ovos-microphone-plugin-pyaudio"}
     },
 
     // if true, will remove silence from both ends of audio before sending it to STT
@@ -522,11 +522,25 @@
         // Energy threshold above which audio is considered speech
         // NOTE: this is dynamic, only defining start value
         "initial_energy_threshold": 1000.0,
-        // vad module can be any plugin, by default it is not used
+
         // recommended plugin: "ovos-vad-plugin-silero"
         "module": "ovos-vad-plugin-silero",
-        "ovos-vad-plugin-silero": {"threshold": 0.2},
-        "ovos-vad-plugin-webrtcvad": {"vad_mode": 3}
+        "ovos-vad-plugin-silero": {
+            "threshold": 0.2,
+            "fallback_module": "ovos-vad-plugin-precise"
+        },
+        "ovos-vad-plugin-precise": {
+            "fallback_module": "ovos-vad-plugin-webrtcvad"
+        },
+        "ovos-vad-plugin-webrtcvad": {
+            "vad_mode": 3,
+            "fallback_module": "ovos-vad-plugin-noise"
+        },
+        "ovos-vad-plugin-noise": {
+            "method": "all",
+            "max_current_ratio_threshold": 2.0,
+            "energy_threshold": 1000.0
+        }
     },
 
     // Override as SYSTEM or USER to select a specific microphone input instead of
@@ -731,7 +745,8 @@
   },
   // turn utterances into phoneme sequences, used to generate mouth movements
   "g2p": {
-     "module": "ovos-g2p-plugin-heuristic-arpa"
+     "module": "ovos-g2p-plugin-mimic",
+     "ovos-g2p-plugin-mimic": {"fallback_module": "ovos-g2p-plugin-heuristic-arpa"}
   },
 
   // DEPRECATED: this section is in the process of being fully removed,
@@ -748,7 +763,17 @@
     //by  default uses public servers for translation
     // https://github.com/OpenVoiceOS/ovos-translate-server
     "detection_module": "ovos-lang-detector-plugin-server",
-    "translation_module": "ovos-translate-plugin-server"
+    "translation_module": "ovos-translate-plugin-server",
+    // define translate fallbacks to use if plugin can not be loaded
+    "ovos-translate-plugin-server": {"fallback_module": "ovos-google-translate-plugin"},
+    // define detect fallbacks to use if plugin can not be loaded
+    "ovos-lang-detector-plugin-server": {"fallback_module": "ovos-google-lang-detector-plugin"},
+    "ovos-google-lang-detector-plugin": {"fallback_module": "ovos-lang-detector-plugin-cld3"},
+    "ovos-lang-detector-plugin-cld3": {"fallback_module": "ovos-lang-detector-plugin-cld2"},
+    "ovos-lang-detector-plugin-cld2": {"fallback_module": "ovos-lang-detector-plugin-langdetect"},
+    "ovos-lang-detector-plugin-langdetect": {"fallback_module": "ovos-lang-detector-plugin-fastlang"},
+    "ovos-lang-detector-plugin-fastlang": {"fallback_module": "ovos-lang-detector-plugin-lingua-podre"},
+    "ovos-lang-detector-plugin-fastlang": {"fallback_module": "ovos-lang-detect-ngram-lm"}
   },
 
   // placeholder to help in migration to ovos-media

--- a/test/unittests/test_configuration.py
+++ b/test/unittests/test_configuration.py
@@ -222,7 +222,7 @@ class TestConfiguration(TestCase):
         from ovos_utils.messagebus import FakeBus
         event = Event()
         bus = FakeBus()
-        thread_config = None
+        thread_config: dict = {}
 
         def _wait_for_changes():
             nonlocal thread_config


### PR DESCRIPTION
similar to WakeWords, allows defining a plugin to load if the primary fails

this is DIFFERENT from fallback TTS/STT, it isnt loaded at same time but instead when main plugin fails to load for any reason

companion to https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/263/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced microphone configuration with a robust fallback mechanism for improved audio input compatibility.
	- Expanded voice activity detection (VAD) capabilities with additional fallback modules for better speech detection.
	- Updated grapheme-to-phoneme processing for improved phoneme generation accuracy.
	- Enriched translation and language detection modules with fallback configurations for increased resilience.

- **Bug Fixes**
	- Adjusted initialization of configuration variables to ensure proper data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->