### PR TITLE
fix:microphone default

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -488,9 +488,9 @@
 
     // Microphone plugin to be read audio
     "microphone": {
-      "module": "ovos-microphone-plugin-sounddevice",
-      "ovos-microphone-plugin-sounddevice": {"fallback_module": "ovos-microphone-plugin-alsa"},
-      "ovos-microphone-plugin-alsa": {"fallback_module": "ovos-microphone-plugin-pyaudio"}
+      "module": "ovos-microphone-plugin-alsa",
+      "ovos-microphone-plugin-alsa": {"fallback_module": "ovos-microphone-plugin-sounddevice"}
+      "ovos-microphone-plugin-sounddevice": {"fallback_module": "ovos-microphone-plugin-pyaudio"},
     },
 
     // if true, will remove silence from both ends of audio before sending it to STT

--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -489,8 +489,8 @@
     // Microphone plugin to be read audio
     "microphone": {
       "module": "ovos-microphone-plugin-alsa",
-      "ovos-microphone-plugin-alsa": {"fallback_module": "ovos-microphone-plugin-sounddevice"}
-      "ovos-microphone-plugin-sounddevice": {"fallback_module": "ovos-microphone-plugin-pyaudio"},
+      "ovos-microphone-plugin-alsa": {"fallback_module": "ovos-microphone-plugin-sounddevice"},
+      "ovos-microphone-plugin-sounddevice": {"fallback_module": "ovos-microphone-plugin-pyaudio"}
     },
 
     // if true, will remove silence from both ends of audio before sending it to STT


### PR DESCRIPTION
go back to using alsa by default as that  change was a semi-breaking change #153 

now that OPM supports plugin fallbacks it isnt an issue if its missing as it will just continue to sounddevice

we can revisit once we have proper mac/windows support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated microphone settings to improve audio input handling.
	- Default microphone module changed to enhance compatibility with ALSA.
- **Bug Fixes**
	- Adjusted fallback modules to ensure better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->