### PR TITLE
fix:catalan_offline_tts

### DIFF
--- a/ovos_config/recommends/offline_female/ca-ba.conf
+++ b/ovos_config/recommends/offline_female/ca-ba.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+        "voice": "balear/olga"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-es.conf
+++ b/ovos_config/recommends/offline_female/ca-es.conf
@@ -1,9 +1,8 @@
 {
   "tts": {
-     "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
-     "ovos-tts-plugin-piper": {
-        "voice": "upc_ona-x_low"
-     }
+    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
+    "ovos-tts-plugin-matxa-multispeaker-cat": {
+        "voice": "central/elia"
+    }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-nw.conf
+++ b/ovos_config/recommends/offline_female/ca-nw.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+        "voice": "nord-occidental/emma"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-va.conf
+++ b/ovos_config/recommends/offline_female/ca-va.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+        "voice": "valencia/gina"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/de-de.conf
+++ b/ovos_config/recommends/offline_female/de-de.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "ramona-low"
      }

--- a/ovos_config/recommends/offline_female/en-gb.conf
+++ b/ovos_config/recommends/offline_female/en-gb.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "alba-medium"
      }

--- a/ovos_config/recommends/offline_female/en-us.conf
+++ b/ovos_config/recommends/offline_female/en-us.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "amy-low"
      }

--- a/ovos_config/recommends/offline_female/es-es.conf
+++ b/ovos_config/recommends/offline_female/es-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "mls_9972-low"
      }

--- a/ovos_config/recommends/offline_female/fr-fr.conf
+++ b/ovos_config/recommends/offline_female/fr-fr.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "siwis-low"
      }

--- a/ovos_config/recommends/offline_female/gl-es.conf
+++ b/ovos_config/recommends/offline_female/gl-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-cotovia",
-     "fallback_module": "",
      "ovos-tts-plugin-cotovia": {
         "voice": "sabela"
      }

--- a/ovos_config/recommends/offline_female/it-it.conf
+++ b/ovos_config/recommends/offline_female/it-it.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "paola-medium"
      }

--- a/ovos_config/recommends/offline_female/nl-nl.conf
+++ b/ovos_config/recommends/offline_female/nl-nl.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "mls_5809-low"
      }

--- a/ovos_config/recommends/offline_male/ca-ba.conf
+++ b/ovos_config/recommends/offline_male/ca-ba.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+      "voice": "balear/quim"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-nw.conf
+++ b/ovos_config/recommends/offline_male/ca-nw.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+      "voice": "nord-occidental/pere"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-va.conf
+++ b/ovos_config/recommends/offline_male/ca-va.conf
@@ -2,7 +2,7 @@
   "tts": {
     "module": "ovos-tts-plugin-matxa-multispeaker-cat",
     "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+      "voice": "valencia/lluc"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/de-de.conf
+++ b/ovos_config/recommends/offline_male/de-de.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "thorsten-low"
      }

--- a/ovos_config/recommends/offline_male/en-gb.conf
+++ b/ovos_config/recommends/offline_male/en-gb.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "alan-low"
      }

--- a/ovos_config/recommends/offline_male/en-us.conf
+++ b/ovos_config/recommends/offline_male/en-us.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "ryan-low"
      }

--- a/ovos_config/recommends/offline_male/es-es.conf
+++ b/ovos_config/recommends/offline_male/es-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "carlfm-x_low"
      }

--- a/ovos_config/recommends/offline_male/fr-fr.conf
+++ b/ovos_config/recommends/offline_male/fr-fr.conf
@@ -3,7 +3,6 @@
 
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "gilles-low"
      }

--- a/ovos_config/recommends/offline_male/gl-es.conf
+++ b/ovos_config/recommends/offline_male/gl-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-cotovia",
-     "fallback_module": "",
      "ovos-tts-plugin-cotovia": {
         "voice": "iago"
      }

--- a/ovos_config/recommends/offline_male/it-it.conf
+++ b/ovos_config/recommends/offline_male/it-it.conf
@@ -2,7 +2,6 @@
 
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "riccardo-x_low"
      }

--- a/ovos_config/recommends/offline_male/nl-nl.conf
+++ b/ovos_config/recommends/offline_male/nl-nl.conf
@@ -2,7 +2,6 @@
 
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "mls-medium"
      }

--- a/ovos_config/recommends/offline_male/pt-br.conf
+++ b/ovos_config/recommends/offline_male/pt-br.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "faber-medium"
      }

--- a/ovos_config/recommends/offline_male/pt-pt.conf
+++ b/ovos_config/recommends/offline_male/pt-pt.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-piper",
-     "fallback_module": "",
      "ovos-tts-plugin-piper": {
         "voice": "tugão-medium"
      }

--- a/ovos_config/recommends/online_female/ca-ba.conf
+++ b/ovos_config/recommends/online_female/ca-ba.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_female/ca-es.conf
+++ b/ovos_config/recommends/online_female/ca-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_female/ca-nw.conf
+++ b/ovos_config/recommends/online_female/ca-nw.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_female/ca-va.conf
+++ b/ovos_config/recommends/online_female/ca-va.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_female/de-de.conf
+++ b/ovos_config/recommends/online_female/de-de.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "ramona-low"
      }

--- a/ovos_config/recommends/online_female/en-gb.conf
+++ b/ovos_config/recommends/online_female/en-gb.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "alba-medium"
      }

--- a/ovos_config/recommends/online_female/en-us.conf
+++ b/ovos_config/recommends/online_female/en-us.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "amy-low"
      }

--- a/ovos_config/recommends/online_female/es-es.conf
+++ b/ovos_config/recommends/online_female/es-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "mls_9972-low"
      }

--- a/ovos_config/recommends/online_female/es-mx.conf
+++ b/ovos_config/recommends/online_female/es-mx.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-google-tx",
-     "fallback_module": "",
      "ovos-tts-plugin-google-tx": {
         "lang": "es-MX",
         "tld": "com.mx"

--- a/ovos_config/recommends/online_female/es-us.conf
+++ b/ovos_config/recommends/online_female/es-us.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-google-tx",
-     "fallback_module": "",
      "ovos-tts-plugin-google-tx": {
         "lang": "es-US",
         "tld": "us"

--- a/ovos_config/recommends/online_female/fr-fr.conf
+++ b/ovos_config/recommends/online_female/fr-fr.conf
@@ -1,6 +1,5 @@
 {  "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "siwis-low"
      }

--- a/ovos_config/recommends/online_female/it-it.conf
+++ b/ovos_config/recommends/online_female/it-it.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "paola-medium"
      }

--- a/ovos_config/recommends/online_female/nl-nl.conf
+++ b/ovos_config/recommends/online_female/nl-nl.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "mls_5809-low"
      }

--- a/ovos_config/recommends/online_female/pt-br.conf
+++ b/ovos_config/recommends/online_female/pt-br.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-google-tx",
-     "fallback_module": "",
      "ovos-tts-plugin-google-tx": {
         "lang": "pt-BR",
         "tld": "com.br"

--- a/ovos_config/recommends/online_female/pt-pt.conf
+++ b/ovos_config/recommends/online_female/pt-pt.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-google-tx",
-     "fallback_module": "",
      "ovos-tts-plugin-google-tx": {
         "lang": "pt-PT",
         "tld": "pt"

--- a/ovos_config/recommends/online_male/ca-ba.conf
+++ b/ovos_config/recommends/online_male/ca-ba.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_male/ca-es.conf
+++ b/ovos_config/recommends/online_male/ca-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_male/ca-nw.conf
+++ b/ovos_config/recommends/online_male/ca-nw.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_male/ca-va.conf
+++ b/ovos_config/recommends/online_male/ca-va.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "host": [
             "https://tts.smartgic.io/matxa",

--- a/ovos_config/recommends/online_male/de-de.conf
+++ b/ovos_config/recommends/online_male/de-de.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "thorsten-low"
      }

--- a/ovos_config/recommends/online_male/en-gb.conf
+++ b/ovos_config/recommends/online_male/en-gb.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "alan-low"
      }

--- a/ovos_config/recommends/online_male/en-us.conf
+++ b/ovos_config/recommends/online_male/en-us.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "ryan-low"
      }

--- a/ovos_config/recommends/online_male/es-es.conf
+++ b/ovos_config/recommends/online_male/es-es.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "carlfm-x_low"
      }

--- a/ovos_config/recommends/online_male/fr-fr.conf
+++ b/ovos_config/recommends/online_male/fr-fr.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "gilles-low"
      }

--- a/ovos_config/recommends/online_male/it-it.conf
+++ b/ovos_config/recommends/online_male/it-it.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "riccardo-x_low"
      }

--- a/ovos_config/recommends/online_male/nl-nl.conf
+++ b/ovos_config/recommends/online_male/nl-nl.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "mls-medium"
      }

--- a/ovos_config/recommends/online_male/pt-br.conf
+++ b/ovos_config/recommends/online_male/pt-br.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "faber-medium"
      }

--- a/ovos_config/recommends/online_male/pt-pt.conf
+++ b/ovos_config/recommends/online_male/pt-pt.conf
@@ -1,7 +1,6 @@
 {
   "tts": {
      "module": "ovos-tts-plugin-server",
-     "fallback_module": "",
      "ovos-tts-plugin-server": {
         "voice": "tugão-medium"
      }


### PR DESCRIPTION
change to Matxa, piper makes many pronounciation mistakes, initial benchmarks show matxa has a good RTF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration files for text-to-speech (TTS) functionality in various languages (e.g., `ca-ba.conf`, `ca-nw.conf`, `ca-va.conf`).
  
- **Bug Fixes**
	- Removed the `fallback_module` key from existing TTS configuration files, streamlining settings and potentially enhancing TTS performance.

These changes improve the customization and reliability of the TTS experience across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->