### PR TITLE
deprecate ready settings

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -105,20 +105,6 @@
   // default to $XDG_DATA_DIRS/$BASE_FOLDER where BASE_FOLDER is read from ovos.conf (default "mycroft")
   // "cache_path": "/tmp/mycroft/cache",
 
-  # emit mycroft.ready signal when all these conditions are met
-  # different setups will have different needs
-  # eg, a server does not care about audio
-  # pairing -> device is paired
-  # internet -> device is connected to the internet - NOT IMPLEMENTED
-  # skills -> skills reported ready
-  # speech -> stt reported ready
-  # audio -> audio playback reported ready
-  # gui -> gui websocket reported ready - NOT IMPLEMENTED
-  # enclosure -> enclosure/HAL reported ready - NOT IMPLEMENTED
-  # network_skills -> skills with network requirements
-  # internet_skills -> skills with internet requirements
-  "ready_settings": ["skills"],
-
   // To enable a utterance transformer plugin just add it's name with any relevant config
   // these plugins can mutate the utterance between STT and the Intent stage
   // they may also modify message.context with metadata


### PR DESCRIPTION
needs companion in ovos-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined configuration by removing the complex `ready_settings` section, simplifying the readiness signal process.

- **Documentation**
	- Added comments for better context on configuration settings hierarchy and implications of overriding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->