### PR TITLE
fix:utterance filename

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -470,7 +470,7 @@
     // "{uuid4}" - a random uuid4
     // "{now:%Y-%m-%dT%H%M%S%z}" - the local ISO datetime
     // "{utcnow:%Y-%m-%dT%H%M%S%z}" - the UTC ISO datetime
-    "utterance_filename": "{hash}-{uuid4}",
+    "utterance_filename": "{md5}-{uuid4}",
 
     "wake_word_upload": {
       "disable": true,


### PR DESCRIPTION
companion to https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/140

the current default value in config is no longer valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the filename generation for saved utterances to enhance uniqueness by using an MD5 hash.

- **Documentation**
	- Added comments for future updates and clarifications regarding the wake word listener settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->