### PR TITLE
fix setting values with absolute key-paths

### DIFF
--- a/ovos_config/__main__.py
+++ b/ovos_config/__main__.py
@@ -386,8 +386,13 @@ def set(key, value):
     ovos-config set -k blacklisted_skills -v myskill    # Adds "myskill" as an blacklisted skill
                                                         # Since this is a pretty specific key and a value is passed, the user won't be prompted
     """
+    absolute_path = key.startswith("/")
     key = key.lstrip("/")
-    tuples = list(walkDict(CONFIG, key, full_path=True))
+
+    if absolute_path:
+        tuples = [(key.split("/"), pathGet(CONFIG, key))]
+    else:
+        tuples = list(walkDict(CONFIG, key, full_path=True))
     values = [tup[1] for tup in tuples]
     paths = ["/".join(tup[0]) for tup in tuples]
 


### PR DESCRIPTION
analogously to
$ ovos-config get -k /location/city/name
one can now set values with absolute key paths
$ ovos-config set -k /location/city/name -v Mycity

addresses https://github.com/OpenVoiceOS/ovos-config/issues/180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality of the `set` command in the configuration management tool for improved handling of absolute paths.
	- Streamlined retrieval of configuration values for better accuracy and efficiency.

- **Bug Fixes**
	- Improved error handling for unmatched keys, ensuring graceful exits and clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->