### PR TITLE
support querying and setting with partial paths as key identifiers

### DIFF
--- a/ovos_config/__main__.py
+++ b/ovos_config/__main__.py
@@ -386,8 +386,13 @@ def set(key, value):
     ovos-config set -k blacklisted_skills -v myskill    # Adds "myskill" as an blacklisted skill
                                                         # Since this is a pretty specific key and a value is passed, the user won't be prompted
     """
+    absolute_path = key.startswith("/")
     key = key.lstrip("/")
-    tuples = list(walkDict(CONFIG, key, full_path=True))
+
+    if absolute_path:
+        tuples = [(key.split("/"), pathGet(CONFIG, key))]
+    else:
+        tuples = list(walkDict(CONFIG, key, full_path=True))
     values = [tup[1] for tup in tuples]
     paths = ["/".join(tup[0]) for tup in tuples]
 


### PR DESCRIPTION
In addition to functionality for setting keys with absolute identifiers, this pull-request also supports partial paths for keys.
E.g.
`$ ovos-config -k get city/name`
will now match `/location/city/name`.
In contrast to that, absolute paths as keys only match the full path. E.g.
`$ ovos-config -k get /city/name`
would not find `/location/city/name`, but only the key `/city/name` if that existed.

For backwards compatibility, each folder name is also matched by substrings. E.g.
`$ ovos-config -k cit/na`
would locate `/location/city/name`.
