### PR TITLE
fix: update STT server urls for pt and ca

### DIFF
--- a/ovos_config/recommends/online_stt/ca-es.conf
+++ b/ovos_config/recommends/online_stt/ca-es.conf
@@ -3,7 +3,9 @@
     "module": "ovos-stt-plugin-server",
     "fallback_module": "",
     "ovos-stt-plugin-server": {
-        "url": [
+        "urls": [
+            "https://stt.smartgic.io/aina/stt",
+            "https://ainastt.ziggyai.online/stt",
             "https://stt.smartgic.io/citrinet/stt",
             "https://citrinetstt.ziggyai.online/stt"
         ]

--- a/ovos_config/recommends/online_stt/pt-pt.conf
+++ b/ovos_config/recommends/online_stt/pt-pt.conf
@@ -1,6 +1,13 @@
 {
   "stt": {
     "module": "ovos-stt-plugin-server",
+    "ovos-stt-plugin-server": {
+        "urls": [
+            "https://stt.smartgic.io/mynorthai/stt",
+            "https://stt.smartgic.io/fasterwhisper/stt",
+            "https://fasterwhisper.ziggyai.online/stt"
+        ]
+    },
     "fallback_module": ""
   }
 }


### PR DESCRIPTION
new dedicated STT models for catalan and portuguese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration for Speech-to-Text (STT) services with multiple endpoint support.
	- Added new URLs for STT services in the Spanish and Portuguese configuration files.

- **Improvements**
	- Renamed key for service endpoints to better reflect multiple URL support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->