### PR TITLE
feat: ovos-config telemetry

### DIFF
--- a/ovos_config/__main__.py
+++ b/ovos_config/__main__.py
@@ -171,6 +171,7 @@ def telemetry(enable, disable):
         config["open_data"]["intent_urls"].remove(url)
         console.print(f"Removed intent telemetry endpoint: {url}")
     console.print(f"Telemetry urls: {config['open_data']['intent_urls']}")
+    config.store()       
 
 
 @config.command()

--- a/ovos_config/__main__.py
+++ b/ovos_config/__main__.py
@@ -148,6 +148,29 @@ def config():
 
 
 @config.command()
+@click.option("--enable", "-e", is_flag=True, help="Enable intent telemetry upload (thank you!)")
+@click.option("--disable", "-d", is_flag=True, help="Disable intent telemetry upload :(")
+def telemetry(enable, disable):
+    """Enable intent telemetry upload for the opendata initiative.
+    OpenData can be seen live at https://opendata.tigregotico.pt"""
+    if enable and disable:
+        raise click.UsageError("Pass either --enable or --disable, not both")
+    config = LocalConf(USER_CONFIG)
+    if "open_data" not in config:
+        config["open_data"] = {"intent_urls": []}
+    if "intent_urls" not in config["open_data"]:
+        config["open_data"]["intent_urls"] = []
+    url = "https://metrics.tigregotico.pt"
+    if enable:
+        config["open_data"]["intent_urls"].append(url)
+        console.print(f"Added intent telemetry endpoint: {url}")
+    elif disable and url in config["open_data"]["intent_urls"]:
+        config["open_data"]["intent_urls"].remove(url)
+        console.print(f"Removed intent telemetry endpoint: {url}")
+    console.print(f"Telemetry urls: {config['open_data']['intent_urls']}")
+
+
+@config.command()
 @click.option("--lang", "-l", required=True, help="the language code")
 @click.option("--hybrid", "-hy", is_flag=True, help="set default offline TTS and online STT plugins")
 @click.option("--online", "-on", is_flag=True, help="set default online TTS and STT plugins")

--- a/ovos_config/__main__.py
+++ b/ovos_config/__main__.py
@@ -162,8 +162,11 @@ def telemetry(enable, disable):
         config["open_data"]["intent_urls"] = []
     url = "https://metrics.tigregotico.pt"
     if enable:
-        config["open_data"]["intent_urls"].append(url)
-        console.print(f"Added intent telemetry endpoint: {url}")
+        if url not in config["open_data"]["intent_urls"]:
+            config["open_data"]["intent_urls"].append(url)
+            console.print(f"Added intent telemetry endpoint: {url}")
+        else:
+            console.print(f"Telemetry endpoint already exists: {url}")
     elif disable and url in config["open_data"]["intent_urls"]:
         config["open_data"]["intent_urls"].remove(url)
         console.print(f"Removed intent telemetry endpoint: {url}")


### PR DESCRIPTION
```bash
(.clean_venv) [miro@miro-homelab OVOS-dev]$ ovos-config telemetry --help

 Usage: ovos-config telemetry [OPTIONS]

 Enable intent telemetry upload for the opendata initiative.  OpenData can be seen live at https://opendata.tigregotico.pt

╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --enable   -e    Enable intent telemetry upload (thank you!)                                                                                                                                                                     │
│ --disable  -d    Disable intent telemetry upload :(                                                                                                                                                                              │
│ --help           Show this message and exit.                                                                                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

(.clean_venv) [miro@miro-homelab OVOS-dev]$ ovos-config telemetry --enable
Added intent telemetry endpoint: https://metrics.tigregotico.pt
Telemetry urls: ['https://metrics.tigregotico.pt']
(.clean_venv) [miro@miro-homelab OVOS-dev]$ ovos-config telemetry --disable
Telemetry urls: []

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a telemetry management command that lets you easily enable or disable intent telemetry upload.
  - Use the `--enable` option to add the telemetry endpoint or `--disable` to remove it.
  - The command ensures only one option is active at a time and provides confirmation messages along with the current telemetry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->