### PR TITLE
Update mycroft.conf

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -205,21 +205,29 @@
 
     // the pipeline is a ordered set of frameworks to send an utterance too
     // if one of the frameworks fails the next one is used, until an answer is found
-    // NOTE: if padatious is not installed, it will be replaced with padacioso (much slower)
-    // in the future these will become plugins, and new pipeline stages can be added by end users
+    // extra pipelines are provided by plugins, e.g.
+    //  - ovos-common-query-pipeline-plugin
+    //  - ovos-ocp-pipeline-plugin-legacy
+    //  - ovos-hivemind-pipeline-plugin
+    //  - ovos-m2v-pipeline-medium
+    //  - ovos-m2v-pipeline-low
+    //  - ovos-adapt-pipeline-plugin-low
+    //  - ovos-padatious-pipeline-plugin-medium
+    //  - ovos-padatious-pipeline-plugin-low
+    //  - ovos-stop-pipeline-plugin-low
     "pipeline": [
-        "stop_high",
-        "converse",
-        "ocp_high",
-        "padatious_high",
-        "adapt_high",
+        "ovos-stop-pipeline-plugin-high",
+        "ovos-converse-pipeline-plugin",
+        "ovos-ocp-pipeline-plugin-high",
+        "ovos-padatious-pipeline-plugin-high",
+        "ovos-adapt-pipeline-plugin-high",
         "ovos-m2v-pipeline-high",
-        "ocp_medium",
-        "fallback_high",
-        "stop_medium",
-        "adapt_medium",
-        "fallback_medium",
-        "fallback_low"
+        "ovos-ocp-pipeline-plugin-medium",
+        "ovos-fallback-pipeline-plugin-high",
+        "ovos-stop-pipeline-plugin-medium",
+        "ovos-adapt-pipeline-plugin-medium",
+        "ovos-fallback-pipeline-plugin-medium",
+        "ovos-fallback-pipeline-plugin-low"
     ]
   },
 

--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -1,5 +1,5 @@
 {
-  // Definition and documentation of all variables used by mycroft-core.
+  // Definition and documentation of all variables used by OpenVoiceOS.
   //
   // Settings seen here are considered DEFAULT.  Settings can also be
   // overridden at the REMOTE level (set by the user via
@@ -18,9 +18,8 @@
   // individual systems can still apply changes at the SYSTEM or USER levels.
 
   // Language used for speech-to-text and text-to-speech.
-  // Code is a BCP-47 identifier (https://tools.ietf.org/html/bcp47), lowercased
-  // TODO: save unmodified, lowercase upon demand
-  "lang": "en-us",
+  // Code is a BCP-47 identifier (https://tools.ietf.org/html/bcp47)
+  "lang": "en-US",
 
   // Secondary languages will also have their resource files loaded into memory
   // but intents will only be considered if that lang is tagged with the utterance at STT step
@@ -106,15 +105,6 @@
     }
   },
 
-  // default to $XDG_DATA_DIRS/mycroft
-  // "data_dir": "/opt/mycroft",
-
-  // by default, files persist across reboots, but be careful with space usage!
-  // TIP: use "/dev/shm/mycroft/cache" if you want to keep the cache in RAM or
-  // use "/tmp/mycroft/cache" to remove files upon reboot
-  // default to $XDG_DATA_DIRS/$BASE_FOLDER where BASE_FOLDER is read from ovos.conf (default "mycroft")
-  // "cache_path": "/tmp/mycroft/cache",
-
   // To enable a utterance transformer plugin just add it's name with any relevant config
   // these plugins can mutate the utterance between STT and the Intent stage
   // they may also modify message.context with metadata
@@ -190,21 +180,14 @@
       // how much extra seconds to allow a skill to search if it requests so
       "extension_time": 3,
       // reranker plugins are responsible for selecting the best answer among skill responses in case of ties
-      // the default is a BM25 implementation from ovos-classifiers
-      "reranker": "ovos-choice-solver-bm25"
+      // the default is https://github.com/TigreGotico/ovos-flashrank-reranker-plugin
+      "reranker": "ovos-flashrank-reranker-plugin"
     },
 
     // OVOS Common Play - handle media requests
     "OCP": {
-      // enable usage of a pretrained classifier for MediaType matching
-      // if disabled a simple .voc match is used
-      // NOTE: classifiers currently are english only
-      "experimental_media_classifier": false,
-      "experimental_binary_classifier": false,
-      // legacy forces old audio service instead of OCP
+      // legacy forces old audio service bus api instead of OCP
       "legacy": false,
-      // min confidence (0.0 - 1.0) to accept MediaType
-      "classifier_threshold": 0.4,
       // min conf for each result (0 - 100)
       "min_score": 40,
       // filter results from "wrong" MediaType
@@ -230,12 +213,11 @@
         "ocp_high",
         "padatious_high",
         "adapt_high",
+        "ovos-m2v-pipeline-high",
         "ocp_medium",
         "fallback_high",
         "stop_medium",
         "adapt_medium",
-        "adapt_low",
-        "common_qa",
         "fallback_medium",
         "fallback_low"
     ]
@@ -244,11 +226,8 @@
   // General skill values
   "skills": {
 
-    // relative to "data_dir"
-    "directory": "skills",
-
     // blacklisted skills to not load
-    // NB: This is skill_id of the skill, usually defined in the skills setup.py
+    // NB: This is skill_id of the skill, defined in the skills setup.py
     "blacklisted_skills": [
         // stop skill has been replaced with native core functionality
         "skill-ovos-stop.openvoiceos"
@@ -599,7 +578,7 @@
   "gui": {
     // Override: SYSTEM (set by specific enclosures)
     // set skill_id of initial homescreen
-    "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
+    "idle_display_skill": "ovos-skill-homescreen.openvoiceos",
 
     // GUI plugins / Extensions provide additional GUI platform support for specific devices
     "extension": "generic",
@@ -664,48 +643,10 @@
     }
   },
 
-  // NLP plugins
-  // split utterances into words
-  // used by downstream tasks, handles lang specific nuances
-  "tokenization": {
-      // default plugin comes bundled with ovos-plugin-manager
-      "module": "ovos-tokenization-plugin-quebrafrases"
-  },
-  // split utterances into sub commands
-  // used to extract multiple intents from a single utterance
-  "segmentation": {
-      // default plugin comes bundled with ovos-plugin-manager
-      "module": "ovos-segmentation-plugin-quebrafrases"
-  },
-  // given an utterance extract keywords from it
-  // can be used to get search terms
-  "keyword_extract": {
-     // default plugin comes bundled with ovos-classifiers
-     "module": "ovos-keyword-extractor-heuristic"
-  },
-  // tag pronouns with the word they refer to
-  // used in normalization step
-  "coref": {
-     // default plugin comes bundled with ovos-classifiers
-     "module": "ovos-coref-solver-heuristic"
-  },
-  "postag": {
-     // default plugin comes bundled with ovos-classifiers
-     "module": "ovos-classifiers-postag-plugin"
-  },
   // turn utterances into phoneme sequences, used to generate mouth movements
   //  disabled by default, only relevant in devices such as the Mark 1
   "g2p": {
      "module": ""
-  },
-
-  // DEPRECATED: this section is in the process of being fully removed,
-  // only providing default values for clean migration
-  "padatious": {
-    // fallback settings for padacioso (pure regex)
-    // set regex_only to False to re-enable padatious (ovos-core < 0.0.8)
-    "regex_only": false,
-    "fuzz": true
   },
 
   // Translation plugins


### PR DESCRIPTION
remove unused and deprecated settings

enable m2v pipeline by default

remove adapt_low and common_qa from default pipeline now that they are their own plugins and not hardcoded in ovos-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated configuration to reflect rebranding from "mycroft-core" to "OpenVoiceOS" in comments.
  - Changed default language code to "en-US" for improved standardization.
  - Updated plugin references and removed deprecated or experimental options for a cleaner configuration.
  - Cleaned up comments and removed obsolete or redundant configuration sections for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->