### PR TITLE
fix: en-us female voice

### DIFF
--- a/ovos_config/recommends/offline_female/en-us.conf
+++ b/ovos_config/recommends/offline_female/en-us.conf
@@ -2,9 +2,9 @@
   "tts": {
     "module": "ovos-tts-plugin-piper",
     "ovos-tts-plugin-piper": {
-      "voice": "dii_en-US",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-US_dii/resolve/main/dii_en-US.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-US_dii/resolve/main/dii_en-US.onnx.json"
+      "voice": "dii_en-GB",
+      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx",
+      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx.json"
     }
   }
 }


### PR DESCRIPTION
not trained yet... use the en-GB voice in the meantime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline female TTS for English now uses a British English voice, providing a UK accent by default.
- Chores
  - Updated TTS configuration to reference the corresponding British English model assets for improved alignment with the selected voice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->