### PR TITLE
enable pre-wake-vad by default

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -429,7 +429,21 @@
     // if true, will remove silence from both ends of audio before sending it to STT
     "remove_silence": true,
 
-    // Voice Activity Detection is used to determine when speech ended
+    // wake word verifier plugins will double check a wake word prediction
+    // they are given a chance to reject wake word activations
+    "ww_verifiers": {
+        "ovos-ww-verifier-silero": {
+            "threshold": 0.1,
+            // does not make sense to enable if "vad_pre_wake_enabled" is set to true
+            "enabled": false
+        }
+    },
+
+    // If enabled will only check for wakeword if VAD also detected speech
+    // this should reduce false activations
+    "vad_pre_wake_enabled": true,
+
+    // Voice Activity Detection is used to determine when users are speaking
     "VAD": {
         // silence method defined the main vad strategy
         // valid values:


### PR DESCRIPTION
related PRs
- https://github.com/OpenVoiceOS/ovos-blogs/pull/24
- https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/189
- https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/191
- https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/341
- https://github.com/OpenVoiceOS/ovos-vad-plugin-silero/pull/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional double-check verification for wake-word activations with configurable thresholds to enhance recognition accuracy.
  * Integrated voice activity detection (VAD) pre-check, ensuring wake-word detection only triggers when speech activity is detected.
  * New configuration options available to customize wake-word verification behavior and sensitivity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->