### PR TITLE
fix:pipeline_config

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -139,15 +139,15 @@
 
     // adjust confidence thresholds for adapt pipeline
     // adapt intents with conf lower than these values will be ignored
-    "adapt": {
+    "ovos-adapt-pipeline-plugin": {
       "conf_high": 0.65,
       "conf_med": 0.45,
       "conf_low": 0.25
     },
 
     // adjust confidence thresholds for padatious pipeline
-    // padatious/padacioso intents with conf lower than these values will be ignored
-    "padatious": {
+    // intents with conf lower than these values will be ignored
+    "ovos-padatious-pipeline-plugin": {
       "conf_high": 0.95,
       "conf_med": 0.8,
       "conf_low": 0.5,
@@ -174,7 +174,7 @@
     },
 
     // Common Query gathers responses to questions from various skills and chooses the best answer
-    "common_query": {
+    "ovos-common-query-pipeline-plugin": {
       // maximum seconds to wait for skill responses before giving up
       "max_response_wait": 6,
       // how much extra seconds to allow a skill to search if it requests so
@@ -185,7 +185,7 @@
     },
 
     // OVOS Common Play - handle media requests
-    "OCP": {
+    "ovos-ocp-pipeline-plugin": {
       // legacy forces old audio service bus api instead of OCP
       "legacy": false,
       // min conf for each result (0 - 100)


### PR DESCRIPTION
since moving to pipeline plugins the plugin_id is expected as key

https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/ovos_plugin_manager/pipeline.py#L91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Intent pipeline configuration keys have been renamed to align with plugin naming conventions for improved clarity. Configuration values and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->