### PR TITLE
feat: phoonnx as the default offline TTS in autoconfigure recommends

### DIFF
--- a/ovos_config/recommends/offline_female/ar-sa.conf
+++ b/ovos_config/recommends/offline_female/ar-sa.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_ar-SA",
-      "model": "https://huggingface.co/OpenVoiceOS/phoonnx_ar-SA_dii_espeak/resolve/main/dii_ar-SA.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/phoonnx_ar-SA_dii_espeak/resolve/main/dii_ar-SA.piper.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_ar_dii_espeak"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-ba.conf
+++ b/ovos_config/recommends/offline_female/ca-ba.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "balear/olga"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 1
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-es.conf
+++ b/ovos_config/recommends/offline_female/ca-es.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/elia"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 3
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-nw.conf
+++ b/ovos_config/recommends/offline_female/ca-nw.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "nord-occidental/emma"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 5
     }
   }
 }

--- a/ovos_config/recommends/offline_female/ca-va.conf
+++ b/ovos_config/recommends/offline_female/ca-va.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "valencia/gina"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 7
     }
   }
 }

--- a/ovos_config/recommends/offline_female/de-de.conf
+++ b/ovos_config/recommends/offline_female/de-de.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_de-DE",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_de-DE_dii/resolve/main/dii_de-DE.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_de-DE_dii/resolve/main/dii_de-DE.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_de-DE_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/en-gb.conf
+++ b/ovos_config/recommends/offline_female/en-gb.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_en-GB",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_en-GB_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/en-us.conf
+++ b/ovos_config/recommends/offline_female/en-us.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_en-GB",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_dii/resolve/main/dii_en-GB.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_en-GB_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/es-es.conf
+++ b/ovos_config/recommends/offline_female/es-es.conf
@@ -1,11 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "sharvard-medium#F"
-    },
-    "ovos-tts-plugin-ahotts": {
-      "lang": "es"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_es-ES_dii_espeak"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/eu-es.conf
+++ b/ovos_config/recommends/offline_female/eu-es.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_eu-ES",
-      "model": "https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_dii_espeak/resolve/main/dii_eu-ES.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_dii_espeak/resolve/main/dii_eu-ES.piper.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_eu-ES_dii_espeak"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/fr-fr.conf
+++ b/ovos_config/recommends/offline_female/fr-fr.conf
@@ -1,8 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "siwis-low"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "piper/fr_FR-siwis-medium"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/gl-es.conf
+++ b/ovos_config/recommends/offline_female/gl-es.conf
@@ -1,8 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-nos",
-    "ovos-tts-plugin-nos": {
-      "voice": "celtia"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "proxectonos/celtia"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/it-it.conf
+++ b/ovos_config/recommends/offline_female/it-it.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_it-IT",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_it-IT_dii/resolve/main/dii_it-IT.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_it-IT_dii/resolve/main/dii_it-IT.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_it-IT_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/nl-nl.conf
+++ b/ovos_config/recommends/offline_female/nl-nl.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_nl-NL",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_nl-NL_dii/resolve/main/dii_nl-NL.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_nl-NL_dii/resolve/main/dii_nl-NL.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_nl-NL_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/pt-br.conf
+++ b/ovos_config/recommends/offline_female/pt-br.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_pt-BR",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_pt-BR_dii/resolve/main/dii_pt-BR.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_pt-BR_dii/resolve/main/dii_pt-BR.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_pt-BR_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_female/pt-pt.conf
+++ b/ovos_config/recommends/offline_female/pt-pt.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "dii_pt-PT",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_pt-PT_dii/resolve/main/dii_pt-PT.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_pt-PT_dii/resolve/main/dii_pt-PT.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_pt-PT_dii"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ar-sa.conf
+++ b/ovos_config/recommends/offline_male/ar-sa.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_ar-SA",
-      "model": "https://huggingface.co/OpenVoiceOS/phoonnx_ar-SA_miro_espeak_V2/resolve/main/miro_ar-SA.onnx.json",
-      "model_config": "https://huggingface.co/OpenVoiceOS/phoonnx_ar-SA_miro_espeak_V2/resolve/main/miro_ar-SA.piper.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_ar_miro_espeak_V2"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-ba.conf
+++ b/ovos_config/recommends/offline_male/ca-ba.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "balear/quim"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 0
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-es.conf
+++ b/ovos_config/recommends/offline_male/ca-es.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "central/grau"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 2
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-nw.conf
+++ b/ovos_config/recommends/offline_male/ca-nw.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "nord-occidental/pere"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 4
     }
   }
 }

--- a/ovos_config/recommends/offline_male/ca-va.conf
+++ b/ovos_config/recommends/offline_male/ca-va.conf
@@ -1,8 +1,9 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-matxa-multispeaker-cat",
-    "ovos-tts-plugin-matxa-multispeaker-cat": {
-      "voice": "valencia/lluc"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 6
     }
   }
 }

--- a/ovos_config/recommends/offline_male/da-dk.conf
+++ b/ovos_config/recommends/offline_male/da-dk.conf
@@ -1,8 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "talesyntese-medium"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_da-DK_miro_espeak"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/de-de.conf
+++ b/ovos_config/recommends/offline_male/de-de.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_de-DE",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_de-DE_miro/resolve/main/miro_de-DE.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_de-DE_miro/resolve/main/miro_de-DE.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_de-DE_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/en-gb.conf
+++ b/ovos_config/recommends/offline_male/en-gb.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_en-GB",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_miro/resolve/main/miro_en-GB.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-GB_miro/resolve/main/miro_en-GB.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_en-GB_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/en-us.conf
+++ b/ovos_config/recommends/offline_male/en-us.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_en-US",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_en-US_miro/resolve/main/miro_en-US.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_en-US_miro/resolve/main/miro_en-US.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_en-US_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/es-es.conf
+++ b/ovos_config/recommends/offline_male/es-es.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_es-ES",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_es-ES_miro/resolve/main/miro_es-ES.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_es-ES_miro/resolve/main/miro_es-ES.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_es-ES_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/eu-es.conf
+++ b/ovos_config/recommends/offline_male/eu-es.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_eu-ES",
-      "model": "https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_miro_espeak/resolve/main/miro_eu-ES.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_miro_espeak/resolve/main/miro_eu-ES.piper.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_eu-ES_miro_espeak"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/fr-fr.conf
+++ b/ovos_config/recommends/offline_male/fr-fr.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_fr-FR",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_fr-FR_miro/resolve/main/miro_fr-FR.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_fr-FR_miro/resolve/main/miro_fr-FR.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_fr-FR_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/gl-es.conf
+++ b/ovos_config/recommends/offline_male/gl-es.conf
@@ -1,8 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-cotovia",
-    "ovos-tts-plugin-cotovia": {
-      "voice": "iago"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/phoonnx_gl-ES_miro_unicode"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/it-it.conf
+++ b/ovos_config/recommends/offline_male/it-it.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_it-IT",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_it-IT_miro/resolve/main/miro_it-IT.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_it-IT_miro/resolve/main/miro_it-IT.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_it-IT_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/nl-nl.conf
+++ b/ovos_config/recommends/offline_male/nl-nl.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_nl-NL",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_nl-NL_miro/resolve/main/miro_nl-NL.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_nl-NL_miro/resolve/main/miro_nl-NL.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_nl-NL_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/pt-br.conf
+++ b/ovos_config/recommends/offline_male/pt-br.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_pt-BR",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_pt-BR_miro/resolve/main/miro_pt-BR.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_pt-BR_miro/resolve/main/miro_pt-BR.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_pt-BR_miro"
     }
   }
 }

--- a/ovos_config/recommends/offline_male/pt-pt.conf
+++ b/ovos_config/recommends/offline_male/pt-pt.conf
@@ -1,10 +1,8 @@
 {
   "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "miro_pt-PT",
-      "model": "https://huggingface.co/OpenVoiceOS/pipertts_pt-PT_miro/resolve/main/miro_pt-PT.onnx",
-      "model_config": "https://huggingface.co/OpenVoiceOS/pipertts_pt-PT_miro/resolve/main/miro_pt-PT.onnx.json"
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/pipertts_pt-PT_miro"
     }
   }
 }


### PR DESCRIPTION
## What

Switches every offline TTS recommend used by `ovos-config autoconfigure` (`recommends/offline_male/*`, `recommends/offline_female/*`) to **`ovos-tts-plugin-phoonnx`**, and updates the per-language voices so the house **miro** (male) / **dii** (female) voices are used wherever they exist.

## Why

phoonnx is a single multi-engine ONNX TTS runner: it serves the native phoonnx miro/dii models **and** loads the legacy piper miro/dii models, so one plugin covers everything and the offline default is consistent across languages. The old configs spread across `ovos-tts-plugin-piper`, `-matxa-multispeaker-cat`, `-cotovia`, `-nos`, `-ahotts`.

## Voice choices (per language × gender)

- **miro / dii** when that voice exists for the language — native phoonnx where trained (`phoonnx_<lang>_<voice>_*`), otherwise the piper model (`pipertts_<lang>_<voice>`, loaded by phoonnx).
- **Catalan** — the multiaccent matxa model `OpenVoiceOS/matxa-cat-multiaccent-wavenext` with a per-dialect/gender `speaker_id` (balear quim 0 / olga 1, central grau 2 / elia 3, nord-occidental pere 4 / emma 5, valencià lluc 6 / gina 7). Requires speaker-selection support: **TigreGotico/phoonnx#200**.
- **Native phoonnx voices** for ar (miro/dii), da-DK (miro), eu-ES (miro/dii), es-ES (dii), gl-ES (miro).
- **pt-PT** — espeak piper voices `pipertts_pt-PT_miro` / `pipertts_pt-PT_dii` (espeak preferred over the tugaphone phonemizer).
- **Fallbacks where no miro/dii exists:** fr-FR female → `piper/fr_FR-siwis-medium`, gl-ES female → `proxectonos/celtia`, en-US female → en-GB dii (no en-US dii trained yet).

The `voice` value is now a phoonnx **catalog id** resolved by phoonnx's model manager, so the old per-voice `model` / `model_config` URLs are dropped from each file.

Online TTS (`ovos-tts-plugin-server`) and STT recommends are unchanged.

## Notes / dependency

- **Depends on TigreGotico/phoonnx#200** (speaker selection) for the Catalan `speaker_id` to take effect; without it Catalan falls back to speaker 0.
- Verified: `autoconfigure --lang ca-es --offline --male` emits `module: ovos-tts-plugin-phoonnx`, voice `matxa-cat-multiaccent-wavenext`, `speaker_id: 2`. All 33 conf files are valid JSON.
- All chosen HF model URLs were HEAD-checked (200/206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated offline voice recommendations for multiple languages including English, Spanish, Portuguese, Catalan, French, German, Dutch, Italian, Arabic, Danish, Basque, and Galician, providing both male and female voice options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->