### PR TITLE
feat: onnx-asr offline STT tier (parakeet + OVOS collection models)

### DIFF
--- a/ovos_config/recommends/offline_stt/ca-es.conf
+++ b/ovos_config/recommends/offline_stt/ca-es.conf
@@ -1,15 +1,9 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "ca"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "Jarbas/faster-whisper-base-ca-cv13",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "OpenVoiceOS/stt-ca-es-conformer-transducer-large-onnx"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/da-dk.conf
+++ b/ovos_config/recommends/offline_stt/da-dk.conf
@@ -1,12 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-fasterwhisper",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/de-de.conf
+++ b/ovos_config/recommends/offline_stt/de-de.conf
@@ -1,15 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "de"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/en-us.conf
+++ b/ovos_config/recommends/offline_stt/en-us.conf
@@ -1,15 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "en"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base.en",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/es-es.conf
+++ b/ovos_config/recommends/offline_stt/es-es.conf
@@ -1,15 +1,9 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "es"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "Jarbas/faster-whisper-base-es-cv13",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "OpenVoiceOS/parakeet-rnnt-1.1b-cv17-es-ep18-1270h-onnx"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/eu-es.conf
+++ b/ovos_config/recommends/offline_stt/eu-es.conf
@@ -1,16 +1,9 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-fasterwhisper",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-HiTZ": {
-      "model": "stt_eu_conformer_transducer_large",
-      "use_cuda": false
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "Jarbas/faster-whisper-base-eu-cv16",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "OpenVoiceOS/stt-eu-conformer-transducer-large-onnx"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/fr-fr.conf
+++ b/ovos_config/recommends/offline_stt/fr-fr.conf
@@ -1,15 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "fr"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/gl-es.conf
+++ b/ovos_config/recommends/offline_stt/gl-es.conf
@@ -1,12 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-fasterwhisper",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "Jarbas/faster-whisper-base-gl-cv13",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "onnx-community/whisper-large-v3-turbo",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/it-it.conf
+++ b/ovos_config/recommends/offline_stt/it-it.conf
@@ -1,15 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "it"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/nl-nl.conf
+++ b/ovos_config/recommends/offline_stt/nl-nl.conf
@@ -1,15 +1,10 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "nl"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "base",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "nemo-parakeet-tdt-0.6b-v3",
+      "quantization": "int8"
     }
   }
 }

--- a/ovos_config/recommends/offline_stt/pt-pt.conf
+++ b/ovos_config/recommends/offline_stt/pt-pt.conf
@@ -1,15 +1,9 @@
 {
   "stt": {
-    "module": "ovos-stt-plugin-citrinet",
+    "module": "ovos-stt-plugin-onnx-asr",
     "fallback_module": "",
-    "ovos-stt-plugin-citrinet": {
-      "lang": "pt"
-    },
-    "ovos-stt-plugin-fasterwhisper": {
-      "model": "Jarbas/faster-whisper-small-pt-MyNorthAI",
-      "use_cuda": false,
-      "compute_type": "int8",
-      "beam_size": 3
+    "ovos-stt-plugin-onnx-asr": {
+      "model": "OpenVoiceOS/whisper-medium-pt-onnx"
     }
   }
 }


### PR DESCRIPTION
## What

Rewrites the offline STT recommends used by `ovos-config autoconfigure` (`recommends/offline_stt/*`) to use **`ovos-stt-plugin-onnx-asr`** for every language, replacing the previous mix of `ovos-stt-plugin-citrinet`, `-fasterwhisper`, and `-HiTZ`.

## Why onnx-asr (vs sherpa-onnx)

Both were considered. onnx-asr won for the default tier:
- **Minimal config** — just `model` (+ optional `quantization`); it auto-detects the architecture from each repo's `config.json` `model_type` and downloads from HF by repo id. sherpa-onnx needs explicit `model_type` + per-artifact `encoder`/`decoder`/`joiner`/`tokens` filenames per release.
- **Best models are onnx-asr-shaped** — NVIDIA Parakeet/Canary and the curated **[OpenVoiceOS/stt-asr-onnx](https://huggingface.co/collections/OpenVoiceOS/stt-asr-onnx)** models are all in onnx-asr's NeMo/Whisper layout.
- sherpa-onnx's strengths (zh/ja/ko/yue SenseVoice, Moonshine) don't help these European langs, and its zoo has no ca/eu/gl models either.

## Model per language (best available offline)

| lang | model | notes |
|------|-------|-------|
| en, de, fr, it, nl, da | `nemo-parakeet-tdt-0.6b-v3` (int8) | SOTA multilingual (25 EU langs), 0.6B, CPU-friendly |
| es | `OpenVoiceOS/parakeet-rnnt-1.1b-cv17-es-ep18-1270h-onnx` | dedicated Spanish fine-tune (collection) |
| pt | `OpenVoiceOS/whisper-medium-pt-onnx` | dedicated European Portuguese (collection) |
| ca | `OpenVoiceOS/stt-ca-es-conformer-transducer-large-onnx` | dedicated Catalan (collection) |
| eu | `OpenVoiceOS/stt-eu-conformer-transducer-large-onnx` | dedicated Basque / HiTZ (collection) |
| gl | `onnx-community/whisper-large-v3-turbo` (int8) | no dedicated gl model in the collection or sherpa zoo |

`quantization: int8` is set only where an int8 export exists (parakeet-v3, whisper-turbo); the collection models ship fp32 only, so it's omitted there (setting it would 404 the int8 files).

## Verification

- Resolver path confirmed against `onnx-asr` source: repos with `/` and no alias → download `config.json` → map `model_type` to the adapter. Curated NeMo repos carry `model_type: nemo-conformer-rnnt`; pt whisper carries `model_type: whisper`.
- Required files present for each: `NemoConformerRnnt` needs `encoder-model.onnx` + `decoder_joint-model.onnx` + `vocab.txt` (preprocessor built in-code — no `nemo128.onnx` needed); whisper repos use the optimum `encoder_model.onnx` + `decoder_model_merged.onnx` layout.
- All 11 conf files valid JSON.
- Not run through full inference (multi-hundred-MB model downloads); validated structurally.

Online STT, GPU STT tier, and TTS recommends are unchanged.

## Notes

- The Spanish (1.1B) and whisper models are heavier than the old citrinet/base-whisper defaults — intentional move upmarket per the "best model" direction; the `gpu/*` tier and platform overrides remain available for constrained devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)