### PR TITLE
fix: include padacioso in the default intent pipeline

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -220,12 +220,14 @@
         "ovos-converse-pipeline-plugin",
         "ovos-ocp-pipeline-plugin-high",
         "ovos-padatious-pipeline-plugin-high",
+        "ovos-padacioso-pipeline-plugin-high",
         "ovos-adapt-pipeline-plugin-high",
         "ovos-m2v-pipeline-high",
         "ovos-ocp-pipeline-plugin-medium",
         "ovos-fallback-pipeline-plugin-high",
         "ovos-stop-pipeline-plugin-medium",
         "ovos-adapt-pipeline-plugin-medium",
+        "ovos-padacioso-pipeline-plugin-medium",
         "ovos-fallback-pipeline-plugin-medium",
         "ovos-fallback-pipeline-plugin-low"
     ]

--- a/test/unittests/test_default_pipeline.py
+++ b/test/unittests/test_default_pipeline.py
@@ -1,0 +1,44 @@
+import unittest
+from os.path import dirname, join
+
+from ovos_utils.json_helper import load_commented_json
+
+DEFAULT_CONFIG = join(dirname(dirname(dirname(__file__))),
+                      "ovos_config", "mycroft.conf")
+
+
+class TestDefaultPipeline(unittest.TestCase):
+    """Validate the intent pipeline shipped in the default mycroft.conf"""
+
+    @classmethod
+    def setUpClass(cls):
+        config = load_commented_json(DEFAULT_CONFIG)
+        cls.pipeline = config["intents"]["pipeline"]
+
+    def test_padacioso_entries_present(self):
+        # padacioso ships with ovos-core itself, so the default pipeline must
+        # include it or a bare install matches no intents at all
+        self.assertIn("ovos-padacioso-pipeline-plugin-high", self.pipeline)
+        self.assertIn("ovos-padacioso-pipeline-plugin-medium", self.pipeline)
+
+    def test_padacioso_high_after_padatious_high(self):
+        # padatious is the preferred matcher when installed; padacioso acts as
+        # its fallback within the same confidence tier
+        self.assertLess(
+            self.pipeline.index("ovos-padatious-pipeline-plugin-high"),
+            self.pipeline.index("ovos-padacioso-pipeline-plugin-high"))
+
+    def test_padacioso_medium_in_medium_tier(self):
+        # the medium entry must come after all high-confidence matchers and
+        # after the medium-tier adapt matcher, but before the medium fallback
+        medium = self.pipeline.index("ovos-padacioso-pipeline-plugin-medium")
+        self.assertGreater(
+            medium, self.pipeline.index("ovos-padacioso-pipeline-plugin-high"))
+        self.assertGreater(
+            medium, self.pipeline.index("ovos-adapt-pipeline-plugin-medium"))
+        self.assertLess(
+            medium, self.pipeline.index("ovos-fallback-pipeline-plugin-medium"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The shipped default `intents.pipeline` only lists matchers that require extra plugins (padatious, adapt, OCP, m2v). None of these ship with a bare `pip install ovos-core[mycroft]`, while padacioso is a base dependency — yet it was absent from the pipeline. A fresh install booted and loaded skills but every utterance went unmatched.

## Changes

- Add `ovos-padacioso-pipeline-plugin-high` immediately after `ovos-padatious-pipeline-plugin-high`, so padatious keeps priority within the high-confidence tier when installed.
- Add `ovos-padacioso-pipeline-plugin-medium` in the medium tier (after `ovos-adapt-pipeline-plugin-medium`, before the medium fallback).
- Uninstalled plugins are skip-filtered at runtime, so existing installs are unaffected.

## Tests

`test/unittests/test_default_pipeline.py` loads the shipped `mycroft.conf` through `load_commented_json` and asserts the padacioso entries are present and correctly ordered relative to their tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)