### PR TITLE
feat: document ww_urls and stt_urls open_data endpoints

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -54,7 +54,22 @@
     // more test data is needed to complement https://gitlocalize-bench.tigregotico.pt and to identity areas of improvement
     "intent_urls": [
        // "https://metrics.tigregotico.pt/intents"
+    ],
+
+    // wake-word audio samples uploaded by the listener (exclusively opt-in)
+    "ww_urls": [
+       // "https://metrics.tigregotico.pt/wake_word"
+    ],
+
+    // transcribed utterance audio samples (exclusively opt-in)
+    "stt_urls": [
+       // "https://metrics.tigregotico.pt/stt"
     ]
+
+    // Optional server configuration
+    // "user_agent": "ovos-metrics",
+    // "api_key": null
+    // optional, sent as X-API-Key header if the server requires it
   },
 
   // File locations of sounds to play for system events


### PR DESCRIPTION
Companion to the [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener) opt-in wake-word and STT sample upload feature. This extends the `open_data` configuration block in `mycroft.conf` to document the `ww_urls` and `stt_urls` endpoints alongside the existing `intent_urls`. Configuration is exclusively opt-in; users must explicitly add URLs to enable data collection.

See [ovos-opendata-server](https://github.com/OpenVoiceOS/ovos-opendata-server) for server implementation.

**Model usage:** Implemented by Claude (Haiku) under Fable orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)