### PR TITLE
fix: get_config_locations() must report remote below distribution/system

### DIFF
--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -71,12 +71,12 @@ def get_config_locations(default=True, web_cache=True, distribution=True,
     ovos_cfg = _ovos_config.get_ovos_config()
     if default:
         locs.append(ovos_cfg["default_config_path"])
+    if web_cache:
+        locs.append(get_webcache_location())
     if distribution:
         locs.append(f"/usr/share/{ovos_cfg['base_folder']}/{ovos_cfg['config_filename']}")
     if system:
         locs.append(f"/etc/{ovos_cfg['base_folder']}/{ovos_cfg['config_filename']}")
-    if web_cache:
-        locs.append(get_webcache_location())
     if old_user:
         locs.append(f"~/.{ovos_cfg['base_folder']}/{ovos_cfg['config_filename']}")
     if user:

--- a/test/unittests/test_locations.py
+++ b/test/unittests/test_locations.py
@@ -58,9 +58,45 @@ class TestLocations(TestCase):
                                               False, False, False
                                               ), list())
         self.assertEqual(get_config_locations(),
-                         ['/test/default.yml', '/usr/share/test/test.yaml',
-                          '/etc/test/test.yaml', 'webcache',
+                         ['/test/default.yml', 'webcache',
+                          '/usr/share/test/test.yaml',
+                          '/etc/test/test.yaml',
                           '~/.test/test.yaml', 'config/test.yaml'])
+
+    @mock.patch("ovos_config.meta.get_ovos_config")
+    @mock.patch("ovos_config.locations.get_webcache_location")
+    @mock.patch("ovos_config.locations.get_xdg_config_save_path")
+    def test_get_config_locations_matches_load_all_configs_priority(
+            self, config_path, webcache_loc, ovos_config):
+        """
+        get_config_locations() is documented as returning paths "sorted by
+        priority". The actual merge precedence is defined in
+        Configuration.load_all_configs() (ovos_config/config.py), where the
+        remote/web_cache config is inserted right after the default config,
+        i.e. below distribution/system/user - not above them. This test
+        pins get_config_locations() to that same order.
+        """
+        ovos_config.return_value = {
+            "test": True,
+            "base_folder": "test",
+            "config_filename": "test.yaml",
+            "default_config_path": "/test/default.yml"
+        }
+        config_path.return_value = "config"
+        webcache_loc.return_value = "webcache"
+        from ovos_config.locations import get_config_locations
+        locs = get_config_locations()
+        expected_order = ['/test/default.yml', 'webcache',
+                          '/usr/share/test/test.yaml',
+                          '/etc/test/test.yaml',
+                          '~/.test/test.yaml', 'config/test.yaml']
+        self.assertEqual(locs, expected_order)
+        # web_cache (remote) must rank below distribution and system,
+        # matching Configuration.load_all_configs() precedence
+        self.assertLess(locs.index('webcache'),
+                        locs.index('/usr/share/test/test.yaml'))
+        self.assertLess(locs.index('/usr/share/test/test.yaml'),
+                        locs.index('/etc/test/test.yaml'))
 
 
     @mock.patch("ovos_config.meta.get_config_filename")


### PR DESCRIPTION
## Summary
- `get_config_locations()` claims to return paths "sorted by priority" but appended `web_cache` (remote) after `distribution`/`system`, implying remote outranks them.
- `Configuration.load_all_configs()` (`ovos_config/config.py`) actually inserts `Configuration.remote` right after `Configuration.default`, so remote is merged (and overridden) before distribution/system, not after.
- Moved the `if web_cache:` append to run immediately after `default`, matching the real precedence: default, remote, distribution, system, old_user, user. No keyword args or defaults changed - only the position of the block.
- Updated the existing `test_get_config_locations` expectation (it encoded the old, wrong order) and added a dedicated regression test pinning the order to `load_all_configs()`'s precedence.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/ -q` -> 29 passed, 1 skipped
- [x] Checked for callers depending on old ordering: only in-repo `find_user_config()` calls `get_config_locations` (with `web_cache=False, distribution=False, system=False`, so unaffected) and the repo's own tests (updated). `gh api search/code -X GET -f q='org:OpenVoiceOS get_config_locations'` returns only this repo.