### PR TITLE
fix: bind gui_websocket to loopback by default, matching the messagebus

### DIFF
--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -354,9 +354,8 @@
 
   // The GUI messagebus websocket.  Once port is created per connected GUI
   "gui_websocket": {
-    // remote display clients (eg. Mark II / DevKit, or any split GUI deployment)
-    // require widening this to "0.0.0.0"; doing so exposes the socket to the
-    // whole network
+    // remote display clients require widening this to "0.0.0.0"; 
+    // doing so exposes the socket to the whole network
     "host": "127.0.0.1",
     "base_port": 18181,
     "route": "/gui",

--- a/ovos_config/mycroft.conf
+++ b/ovos_config/mycroft.conf
@@ -354,7 +354,10 @@
 
   // The GUI messagebus websocket.  Once port is created per connected GUI
   "gui_websocket": {
-    "host": "0.0.0.0",
+    // remote display clients (eg. Mark II / DevKit, or any split GUI deployment)
+    // require widening this to "0.0.0.0"; doing so exposes the socket to the
+    // whole network
+    "host": "127.0.0.1",
     "base_port": 18181,
     "route": "/gui",
     "ssl": false


### PR DESCRIPTION
## Summary

- The GUI WebSocket is unauthenticated. Messages received on it are translated into emits on the core messagebus (see `ovos-gui`, `ovos_gui/bus.py`), so it carries the same authority as the messagebus itself.
- The core messagebus (`websocket` block) already defaults to `127.0.0.1`. The `gui_websocket` block defaulted to `0.0.0.0`, which is inconsistent with that and makes the more-permissive default the one users are least likely to notice.
- This PR aligns the two defaults by binding `gui_websocket.host` to `127.0.0.1`, and adds a comment noting that remote display clients need to widen it back to `0.0.0.0` explicitly.

## Breaking change

This is a **breaking default change** for any deployment with a GUI client on a different machine than ovos-core (e.g. Mark II / DevKit setups, or any other split GUI deployment). Those setups will need to set `gui_websocket.host` explicitly (e.g. to `0.0.0.0` or the specific reachable address) after upgrading.

Opened as a draft for the maintainer to decide on scope, including whether this needs a migration note and/or a major-version bump.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/ -q` → 28 passed, 1 skipped (no test asserted the old `0.0.0.0` default)
- [ ] Maintainer sign-off on breaking-change handling (docs/migration note/version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)