### PR TITLE
fix: reload the distribution config layer in Configuration.reload()

### DIFF
--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -137,6 +137,7 @@ class Configuration(dict):
         Reload all configuration files
         """
         Configuration.default.reload()
+        Configuration.distribution.reload()
         Configuration.system.reload()
         Configuration.remote.reload()
         for cfg in Configuration.xdg_configs:


### PR DESCRIPTION
`Configuration.reload()` re-reads default, system, remote and xdg user layers but omits `Configuration.distribution.reload()`, so edits to `/usr/share/mycroft/mycroft.conf` are ignored on an explicit reload (e.g. the `configuration.updated` bus handler) until a process restart — while the FileWatcher path *does* watch that file, so the two refresh paths disagree. One-line fix adds the missing reload. Found auditing ovos-config for the Technical Manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)