### PR TITLE
fix: user config must win over /etc/xdg, not lose to it

### DIFF
--- a/ovos_config/config.py
+++ b/ovos_config/config.py
@@ -37,7 +37,8 @@ class Configuration(dict):
     system = MycroftSystemConfig()
     remote = RemoteConf()
     # This includes both the user config and
-    # /etc/xdg/mycroft/mycroft.conf
+    # /etc/xdg/mycroft/mycroft.conf, in merge order: the user's own file is
+    # last, so it wins over the system-wide XDG dirs
     xdg_configs = [LocalConf(p) for p in get_xdg_config_locations()]
     _watchdog = None
     _callbacks = []

--- a/ovos_config/locations.py
+++ b/ovos_config/locations.py
@@ -90,14 +90,17 @@ def get_webcache_location():
 
 
 def get_xdg_config_locations():
-    """ return list of possible XDG config full file paths taking into account ovos.conf """
-    # This includes both the user config and
-    # /etc/xdg/mycroft/mycroft.conf
-    xdg_paths = list(reversed(
-        [join(p, _ovos_config.get_config_filename())
-         for p in get_xdg_config_dirs()]
-    ))
-    return xdg_paths
+    """Return the XDG config file paths, in merge order.
+
+    The list runs from lowest to highest precedence, ie the way
+    ``Configuration`` merges them: system-wide XDG dirs first, then
+    ``$XDG_CONFIG_HOME`` last. The user's own file is therefore the last
+    entry, and it wins.
+
+    This includes both the user config and /etc/xdg/mycroft/mycroft.conf.
+    """
+    return [join(p, _ovos_config.get_config_filename())
+            for p in get_xdg_config_dirs()]
 
 
 def find_default_config():

--- a/test/unittests/test_locations.py
+++ b/test/unittests/test_locations.py
@@ -11,6 +11,44 @@ class TestLocations(TestCase):
         directories = get_xdg_config_dirs("test")
         self.assertIn(expanduser("~/.config/test"), directories)
 
+    def test_xdg_config_locations_are_in_merge_order(self):
+        # Configuration merges this list left to right, so the last entry
+        # wins. Per the XDG base directory spec that must be the user's own
+        # $XDG_CONFIG_HOME file, not a system-wide dir such as /etc/xdg.
+        from ovos_config.locations import get_xdg_config_locations, \
+            get_xdg_config_save_path
+        from ovos_config.meta import get_config_filename
+        locations = get_xdg_config_locations()
+        user_config = join(get_xdg_config_save_path(), get_config_filename())
+        self.assertEqual(locations[-1], user_config)
+
+    def test_user_config_overrides_etc_xdg(self):
+        # regression: get_xdg_config_locations() used to return the user file
+        # first, which meant /etc/xdg/mycroft/mycroft.conf silently won.
+        import json
+        import tempfile
+        from ovos_config.config import Configuration
+        from ovos_config.models import LocalConf
+
+        with tempfile.TemporaryDirectory() as tmp:
+            etc_xdg = join(tmp, "etc-xdg.conf")
+            user = join(tmp, "user.conf")
+            with open(etc_xdg, "w") as f:
+                json.dump({"lang": "de-DE"}, f)
+            with open(user, "w") as f:
+                json.dump({"lang": "pt-PT"}, f)
+
+            old = Configuration.xdg_configs
+            try:
+                # merge order: system-wide XDG dirs first, user's own last
+                Configuration.xdg_configs = [LocalConf(etc_xdg),
+                                             LocalConf(user)]
+                Configuration.clear_cache()
+                self.assertEqual(Configuration()["lang"], "pt-PT")
+            finally:
+                Configuration.xdg_configs = old
+                Configuration.clear_cache()
+
     def test_get_data_dirs(self):
         from ovos_config.locations import get_xdg_data_dirs
         directories = get_xdg_data_dirs("test")


### PR DESCRIPTION
## The bug

`get_xdg_config_locations()` reverses the list it builds, so it returns
`$XDG_CONFIG_HOME` **first** and the system-wide XDG dirs **last**.

`Configuration` merges `xdg_configs` left to right, so the last entry wins. The
net effect is that `/etc/xdg/mycroft/mycroft.conf` silently overrides the user's
own `~/.config/mycroft/mycroft.conf`.

That inverts the [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/),
which gives `$XDG_CONFIG_HOME` the highest precedence — and it contradicts every
doc and support answer that tells users to edit their own file.

## Reproducing it on `dev`

```bash
mkdir -p /tmp/x/home/mycroft /tmp/x/etcxdg/mycroft
echo '{"lang": "pt-PT"}' > /tmp/x/home/mycroft/mycroft.conf
echo '{"lang": "de-DE"}' > /tmp/x/etcxdg/mycroft/mycroft.conf

XDG_CONFIG_HOME=/tmp/x/home XDG_CONFIG_DIRS=/tmp/x/etcxdg python3 -c "
from ovos_config.config import Configuration
print(Configuration()['lang'])"
```

Before this PR that prints `de-DE` — the system-wide file. After it, `pt-PT`.

## The fix

Drop the reversal so the list comes back in merge order, lowest precedence
first.

The reversal dates back to the original `ovos_utils.configuration` migration
(#7/#8), where a highest-priority-first list made sense for a first-match-wins
search. The only consumer today is the merge in `Configuration`, which wants the
opposite order. The docstring now states the order the merge relies on, so the
next reader does not have to work it out from the merge site.

`get_xdg_config_locations` is exported from `ovos_config`, so this is a
behaviour change for any out-of-tree caller that relied on the reversed order. I
found no such caller in the OVOS org.

## Tests

Two added to `test/unittests/test_locations.py`:

- `test_xdg_config_locations_are_in_merge_order` — the user's own file is last.
  **Fails on `dev`**, passes here.
- `test_user_config_overrides_etc_xdg` — end-to-end through `Configuration`,
  pinning the behaviour so a future reordering cannot regress it quietly.

Full suite: 30 passed, 1 skipped.

## How this surfaced

Found while auditing the ovos-technical-manual configuration pages against
source. Three pages documented the precedence the other way round; those are
being corrected separately, to match whatever this PR settles on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected XDG configuration merging so system-wide settings load first and user settings load last.
  * User configuration now consistently takes precedence over system-wide configuration values.

* **Documentation**
  * Clarified configuration loading order and precedence in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->