### PR TITLE
fix: unbreak the release pipeline, and ship a usable sdist

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -49,13 +49,13 @@ jobs:
           python-version: "3.14"
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: version
-        run: echo "::set-output name=version::$(python setup.py --version)"
+        run: echo "version=$(python setup.py --version)" >> "$GITHUB_OUTPUT"
         id: version
       - name: Build Distribution Packages
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel --no-isolation
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
@@ -76,6 +76,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+
+      - name: Install Build Tools
+        run: |
+          python -m pip install setuptools
 
       - name: Get version from setup.py
         id: get_version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# setup.py reads the requirements files at build time, so an sdist without
+# them cannot be built into a wheel, and a source install fails.
+include requirements/*.txt
+include README.md
+include LICENSE
+recursive-include ovos_config *.conf *.json *.yml *.yaml


### PR DESCRIPTION
## Bug 1 — the release pipeline has been failing

Both `publish_pypi` and `propose_release` run `python setup.py` on a runner
pinned to Python 3.14, which no longer installs setuptools by default. Both die
before doing anything:

```
File "/home/runner/work/ovos-config/ovos-config/setup.py", line 16, in <module>
    from setuptools import setup
ModuleNotFoundError: No module named 'setuptools'
```

`pip install build wheel` does not pull setuptools in, so the install step does
not cover it.

This is live: the `2.3.7a1` alpha cut when #284 merged **never reached PyPI**.
Every alpha since the 3.14 bump is in the same state.

Fixed by installing setuptools in both jobs.

Also replaced `::set-output`, which GitHub
[disabled in 2023](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/),
with `$GITHUB_OUTPUT`.

## Bug 2 — the sdist cannot be built or installed

Found while verifying the fix. There is no `MANIFEST.in`, so the sdist ships
without `requirements/`. `setup.py` reads those files at build time, so building
a wheel from the sdist fails:

```
FileNotFoundError: .../ovos_config-2.3.7a1/requirements/requirements.txt
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

The **published 2.1.1 sdist has the same gap** — I downloaded it and checked; it
contains no `requirements/` entries. So `pip install ovos-config` has been
broken for anyone who cannot use the wheel (a source-only install, a distro
package build, `--no-binary`).

Fixed with a `MANIFEST.in`.

With the sdist complete, the build step can use `python -m build`, which builds
the wheel *from the sdist*. That means every release exercises the source path
instead of leaving it to fail silently in someone's install.

## Verification

In a venv with no setuptools, mimicking the 3.14 runner:

```
bare venv has setuptools: False
setup.py --version -> 1 ModuleNotFoundError: No module named 'setuptools'
after installing setuptools -> 0 2.3.7a1
```

Then, with `MANIFEST.in` in place:

```
Successfully built ovos_config-2.3.7a1.tar.gz and ovos_config-2.3.7a1-py3-none-any.whl
requirements/ present in sdist: requirements.txt, tests.txt
```

And a clean `pip install` of that sdist into a fresh venv imports fine.

## Scope

Only `ovos-config` carries this workflow shape — I checked `ovos-bus-client`,
`ovos-plugin-manager`, `ovos-utils`, `ovos-workshop` and `ovos-core`, and none
of them run `setup.py` this way.

## How this surfaced

Noticed because the release run on #284 went red.